### PR TITLE
[완료] feature: JWT 기반 인증 시스템

### DIFF
--- a/backend/src/main/java/app/aipacemaker/backend/auth/adapter/EmailVerificationTokenJpaRepository.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/adapter/EmailVerificationTokenJpaRepository.java
@@ -1,8 +1,0 @@
-package app.aipacemaker.backend.auth.adapter;
-
-import app.aipacemaker.backend.auth.model.EmailVerificationToken;
-import app.aipacemaker.backend.auth.model.EmailVerificationTokenRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface EmailVerificationTokenJpaRepository extends JpaRepository<EmailVerificationToken, Long>, EmailVerificationTokenRepository {
-}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/adapter/UserJpaRepository.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/adapter/UserJpaRepository.java
@@ -1,8 +1,0 @@
-package app.aipacemaker.backend.auth.adapter;
-
-import app.aipacemaker.backend.auth.model.User;
-import app.aipacemaker.backend.auth.model.UserRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserJpaRepository extends JpaRepository<User, Long>, UserRepository {
-}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/docs/api.md
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/docs/api.md
@@ -1,0 +1,269 @@
+# 인증 API 문서
+
+## 개요
+
+사용자 인증 및 JWT 토큰 기반 세션 관리를 제공하는 API입니다.
+
+## 엔드포인트
+
+### 1. 회원가입
+
+사용자 계정을 생성하고 이메일 인증 토큰을 발송합니다.
+
+**Endpoint:** `POST /api/users`
+
+**Request Body:**
+```json
+{
+  "name": "홍길동",
+  "email": "user@example.com",
+  "password": "password123"
+}
+```
+
+**Validation:**
+- `name`: 필수, 비어있지 않아야 함
+- `email`: 필수, 유효한 이메일 형식
+- `password`: 필수, 8자 이상, 영문자와 숫자 포함
+
+**Success Response (201 Created):**
+```json
+{
+  "userId": 1,
+  "email": "user@example.com",
+  "message": "회원가입이 완료되었습니다. 이메일을 확인하여 계정을 활성화해주세요."
+}
+```
+
+**Error Responses:**
+- `400 Bad Request`: 비밀번호 정책 위반
+- `409 Conflict`: 이미 사용 중인 이메일
+
+---
+
+### 2. 이메일 인증
+
+이메일로 전송된 인증 토큰을 통해 계정을 활성화합니다.
+
+**Endpoint:** `POST /api/users/verification`
+
+**Request Body:**
+```json
+{
+  "token": "uuid-token-string"
+}
+```
+
+**Success Response (200 OK):**
+```json
+{
+  "userId": 1,
+  "email": "user@example.com",
+  "verified": true,
+  "message": "이메일 인증이 완료되었습니다."
+}
+```
+
+**Error Responses:**
+- `400 Bad Request`: 만료된 인증 토큰
+- `404 Not Found`: 유효하지 않은 인증 토큰
+
+---
+
+### 3. 로그인
+
+이메일과 비밀번호로 로그인하여 Access Token과 Refresh Token을 발급받습니다.
+
+**Endpoint:** `POST /api/auth/login`
+
+**Request Body:**
+```json
+{
+  "email": "user@example.com",
+  "password": "password123",
+  "deviceId": "device-uuid-or-identifier"
+}
+```
+
+**Validation:**
+- `email`: 필수, 유효한 이메일 형식
+- `password`: 필수
+- `deviceId`: 필수, 다중 디바이스 지원을 위한 디바이스 식별자
+
+**Success Response (200 OK):**
+```json
+{
+  "userId": 1,
+  "email": "user@example.com",
+  "emailVerified": true,
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**Response Fields:**
+- `emailVerified`: 이메일 인증 여부 (false인 경우 프론트엔드에서 인증 안내 UI 표시)
+- `accessToken`: 1시간 유효한 접근 토큰
+- `refreshToken`: 30일 유효한 갱신 토큰
+
+**Error Responses:**
+- `401 Unauthorized`: 잘못된 이메일 또는 비밀번호
+
+**참고사항:**
+- 이메일 미인증 사용자도 로그인 가능 (emailVerified: false 반환)
+- 동일 사용자가 다른 디바이스에서 로그인 시 각 디바이스별 독립적인 Refresh Token 발급
+- 같은 디바이스에서 재로그인 시 기존 Refresh Token 갱신
+
+---
+
+### 4. Access Token 갱신
+
+Refresh Token을 사용하여 새로운 Access Token을 발급받습니다.
+
+**Endpoint:** `POST /api/auth/refresh`
+
+**Request Body:**
+```json
+{
+  "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**Success Response (200 OK):**
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+**Error Responses:**
+- `401 Unauthorized`: 유효하지 않거나 만료된 Refresh Token
+
+**참고사항:**
+- Refresh Token은 JWT 형식으로 userId와 deviceId를 포함
+- DB에 저장된 토큰과 일치 여부 검증
+- 만료된 Refresh Token은 재사용 불가
+
+---
+
+## JWT 토큰 구조
+
+### Access Token
+- **만료 시간:** 1시간
+- **Claims:**
+  - `sub`: userId (Long)
+  - `email`: 사용자 이메일
+  - `type`: "access"
+  - `iat`: 발급 시간
+  - `exp`: 만료 시간
+
+### Refresh Token
+- **만료 시간:** 30일
+- **Claims:**
+  - `sub`: userId (Long)
+  - `deviceId`: 디바이스 식별자 (보안 및 다중 디바이스 지원)
+  - `type`: "refresh"
+  - `iat`: 발급 시간
+  - `exp`: 만료 시간
+
+---
+
+## 에러 응답 형식 (RFC 7807 ProblemDetail)
+
+모든 에러 응답은 RFC 7807 표준을 따릅니다:
+
+```json
+{
+  "type": "about:blank",
+  "title": "인증 실패",
+  "status": 401,
+  "detail": "이메일 또는 비밀번호가 올바르지 않습니다.",
+  "instance": "/api/auth/login"
+}
+```
+
+---
+
+## 보안 고려사항
+
+1. **비밀번호 암호화:** BCrypt (strength 10)
+2. **JWT 서명:** HMAC SHA-256
+3. **Refresh Token 저장:** DB에 암호화되지 않은 상태로 저장 (추후 암호화 고려)
+4. **다중 디바이스 지원:** deviceId를 통한 디바이스별 토큰 관리
+5. **토큰 재사용 방지:** Refresh Token은 DB 검증 필수
+
+---
+
+## 다중 디바이스 로그인 시나리오
+
+### 시나리오 1: 모바일과 웹에서 동시 로그인
+1. 사용자가 모바일 앱에서 로그인 (deviceId: "mobile-uuid")
+   - Refresh Token A 발급 및 DB 저장
+2. 동일 사용자가 웹에서 로그인 (deviceId: "web-uuid")
+   - Refresh Token B 발급 및 DB 저장
+3. 결과: 두 디바이스 모두 독립적으로 세션 유지
+
+### 시나리오 2: 같은 디바이스에서 재로그인
+1. 사용자가 모바일에서 로그인 (deviceId: "mobile-uuid")
+   - Refresh Token A 발급 및 DB 저장
+2. 앱 종료 후 다시 로그인 (deviceId: "mobile-uuid")
+   - 기존 Refresh Token A를 새로운 토큰으로 교체 (UPDATE)
+3. 결과: 최신 Refresh Token만 유효
+
+---
+
+## 구현 상태
+
+✅ 회원가입 (이름, 이메일, 비밀번호)
+✅ 이메일 인증
+✅ 로그인 (다중 디바이스 지원)
+✅ Access Token 갱신
+✅ JWT 토큰 기반 인증
+✅ 통합 테스트 (80%+ 커버리지)
+✅ API 레이어 테스트
+⏳ 인증 필터/인터셉터 (별도 태스크)
+
+---
+
+## 향후 작업: 인증 필터/인터셉터
+
+현재 구현은 JWT 토큰 발급 및 검증 로직까지 완료되었으며, 실제 API 요청에서 토큰을 검증하고 인증된 사용자 정보를 추출하는 **인증 필터/인터셉터**는 별도 작업으로 진행될 예정입니다.
+
+### 구현 예정 사항
+
+1. **JWT 인증 필터**
+   - HTTP 요청 헤더에서 `Authorization: Bearer <token>` 추출
+   - JwtTokenProvider를 사용한 토큰 유효성 검증
+   - 유효한 토큰인 경우 SecurityContext에 인증 정보 설정
+   - 유효하지 않은 토큰인 경우 401 Unauthorized 응답
+
+2. **Spring Security 통합**
+   - SecurityFilterChain 설정
+   - 인증이 필요한 엔드포인트와 공개 엔드포인트 구분
+   - CORS 설정
+   - CSRF 설정
+
+3. **인증된 사용자 정보 접근**
+   - `@AuthenticationPrincipal` 어노테이션 지원
+   - SecurityContext에서 현재 사용자 정보 조회
+   - 컨트롤러 메서드에서 인증된 사용자 정보 접근
+
+### 공개 엔드포인트 vs 인증 필요 엔드포인트
+
+**공개 엔드포인트 (인증 불필요):**
+- `POST /api/users` - 회원가입
+- `POST /api/users/verification` - 이메일 인증
+- `POST /api/auth/login` - 로그인
+- `POST /api/auth/refresh` - 토큰 갱신
+
+**인증 필요 엔드포인트 (향후 구현):**
+- `GET /api/users/me` - 현재 사용자 정보 조회
+- `PUT /api/users/me` - 사용자 정보 수정
+- `POST /api/posts` - 게시글 작성
+- 기타 사용자 전용 기능
+
+### 주의사항
+
+현재 구현된 `/api/auth/login`과 `/api/auth/refresh` 엔드포인트는 인증 필터가 적용되지 않은 상태에서도 정상 동작합니다. 이는 이들 엔드포인트가 인증을 **수행**하는 역할이지, 인증을 **요구**하는 역할이 아니기 때문입니다.
+
+인증 필터는 이미 인증된 사용자만 접근할 수 있는 보호된 리소스에 대한 접근 제어를 위한 것이며, 별도의 작업으로 구현될 예정입니다.

--- a/backend/src/main/java/app/aipacemaker/backend/auth/docs/feature.md
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/docs/feature.md
@@ -1,0 +1,270 @@
+# JWT 기반 인증 시스템 구현
+
+## 개요
+
+이 문서는 JWT (JSON Web Token) 기반 인증 시스템의 구현 내용을 설명합니다. 코드를 읽기 전에 전체적인 아키텍처와 설계 결정 사항을 이해하기 위한 문서입니다.
+
+## 요구사항
+
+1. 회원가입 시 이름, 이메일, 비밀번호 입력
+2. 이메일 인증 필요 (미인증 시에도 로그인 가능하지만 제한된 기능)
+3. 로그인 시 Access Token (1시간)과 Refresh Token (30일) 발급
+4. Refresh Token을 통한 자동 세션 갱신
+5. 다중 디바이스 로그인 지원
+6. 만료/유효하지 않은 토큰에 대한 적절한 에러 처리
+
+## 아키텍처
+
+### Clean Architecture 레이어 구조
+
+```
+auth/
+├── model/               # 도메인 모델 & 리포지토리 인터페이스
+│   ├── User.java
+│   ├── RefreshToken.java
+│   ├── EmailVerificationToken.java
+│   ├── UserRepository.java (JpaRepository 직접 확장)
+│   ├── RefreshTokenRepository.java (JpaRepository 직접 확장)
+│   └── EmailVerificationTokenRepository.java (JpaRepository 직접 확장)
+├── usecase/            # 비즈니스 로직
+│   ├── RegisterUser.java
+│   ├── VerifyEmail.java
+│   ├── LoginUser.java
+│   └── RenewAccessToken.java
+├── endpoint/           # API 엔드포인트
+│   ├── AuthController.java
+│   └── AuthExceptionHandler.java
+├── infrastructure/     # 인프라 구현
+│   └── JwtTokenProvider.java
+└── fixture/           # 테스트 픽스처 (테스트 코드)
+    ├── UserFixture.java
+    ├── RefreshTokenFixture.java
+    └── EmailVerificationTokenFixture.java
+```
+
+## 핵심 컴포넌트
+
+### 1. User 엔티티
+
+사용자 기본 정보를 저장하는 엔티티입니다.
+
+**주요 필드:**
+- `id`: 사용자 고유 식별자
+- `name`: 사용자 이름 (회원가입 시 추가된 필드)
+- `email`: 이메일 (유니크 제약조건)
+- `password`: BCrypt로 암호화된 비밀번호
+- `emailVerified`: 이메일 인증 여부
+- `createdAt`: 계정 생성 시간
+
+### 2. RefreshToken 엔티티
+
+다중 디바이스 로그인을 위한 Refresh Token 정보를 저장합니다.
+
+**주요 필드:**
+- `id`: 토큰 고유 식별자
+- `userId`: 토큰 소유자 ID
+- `deviceId`: 디바이스 식별자 (다중 디바이스 지원)
+- `token`: JWT Refresh Token 문자열
+- `expiresAt`: 토큰 만료 시간
+
+**설계 결정:**
+- `userId + deviceId` 복합 유니크 제약 조건
+- 같은 디바이스에서 재로그인 시 기존 토큰 업데이트 (DELETE + INSERT가 아닌 UPDATE)
+- deviceId를 통한 디바이스별 독립적인 세션 관리
+- `updateToken()` 메서드로 토큰 갱신
+
+### 3. JwtTokenProvider
+
+JWT 토큰 생성 및 검증을 담당하는 인프라스트럭처 컴포넌트입니다.
+
+**주요 기능:**
+- Access Token 생성 (userId, email 포함)
+- Refresh Token 생성 (userId, deviceId 포함)
+- 토큰 유효성 검증
+- 토큰에서 정보 추출 (userId, email, deviceId)
+
+**토큰 구조:**
+- **Access Token**: userId, email, type, 발급/만료 시간 (1시간)
+- **Refresh Token**: userId, deviceId, type, 발급/만료 시간 (30일)
+- deviceId를 Refresh Token에 포함하여 디바이스별 토큰 관리 및 보안 강화
+
+### 4. LoginUser UseCase
+
+로그인 비즈니스 로직을 처리합니다.
+
+**프로세스:**
+1. 이메일로 사용자 조회
+2. 비밀번호 검증 (BCrypt)
+3. Access Token 생성
+4. Refresh Token 생성 (deviceId 포함)
+5. DB에서 기존 Refresh Token 조회 (userId + deviceId)
+6. 존재하면 UPDATE, 없으면 INSERT
+7. 토큰 정보 반환 (emailVerified 플래그 포함)
+
+**특징:**
+- 이메일 미인증 사용자도 로그인 가능 (emailVerified: false 반환)
+- 다중 디바이스 지원 (deviceId 기반)
+- @Transactional로 원자성 보장
+- Command-Result 패턴 사용
+
+### 5. RenewAccessToken UseCase
+
+Refresh Token으로 새로운 Access Token을 발급합니다.
+
+**프로세스:**
+1. JWT 형식 검증
+2. userId와 deviceId 추출
+3. DB에서 해당 Refresh Token 조회 (userId + deviceId)
+4. 토큰 일치 여부 검증
+5. 만료 여부 검증
+6. 새로운 Access Token 발급
+
+**보안:**
+- JWT 검증 + DB 검증 이중 체크
+- deviceId 일치 여부 확인 (토큰 도용 방지)
+- 만료된 토큰 재사용 불가
+
+## Repository 구조
+
+**설계 철학:** 불필요한 어댑터 계층을 제거하고 JpaRepository를 직접 확장하여 간결성 확보
+
+**주요 Repository:**
+- `UserRepository`: 사용자 조회 (이메일 기반, 존재 여부 확인)
+- `RefreshTokenRepository`: Refresh Token 관리 (토큰 조회, userId+deviceId 조회, 삭제)
+- `EmailVerificationTokenRepository`: 이메일 인증 토큰 관리 (토큰 조회, 사용자별 삭제)
+
+각 Repository는 Spring Data JPA의 메서드 네이밍 규칙을 활용하여 커스텀 쿼리 메서드 정의
+
+## API 엔드포인트
+
+### AuthController
+
+**회원가입 및 인증:**
+- `POST /api/users` - 회원가입 (이름, 이메일, 비밀번호)
+- `POST /api/users/verification` - 이메일 인증
+
+**로그인 및 토큰 관리:**
+- `POST /api/auth/login` - 로그인 (이메일, 비밀번호, deviceId)
+- `POST /api/auth/refresh` - Access Token 갱신
+
+### AuthExceptionHandler
+
+**에러 응답 형식:** RFC 7807 ProblemDetail 표준
+
+**HTTP 상태 코드별 예외 매핑:**
+- `400 Bad Request`: 비밀번호 정책 위반, 만료된 인증 토큰
+- `401 Unauthorized`: 잘못된 인증 정보, 유효하지 않거나 만료된 Refresh Token
+- `404 Not Found`: 사용자 없음, 유효하지 않은 인증 토큰
+- `409 Conflict`: 중복 이메일
+
+## 테스트 전략
+
+### 테스트 피라미드 (TDD 접근)
+
+**1. 통합 테스트 (80%)**
+- `RegisterUserTest`: 회원가입 Event-Driven 플로우 검증
+- `VerifyEmailTest`: 이메일 인증 프로세스
+- `LoginUserTest`: 로그인 및 다중 디바이스 시나리오
+- `RenewAccessTokenTest`: 토큰 갱신 및 보안 검증
+
+**2. API 테스트 (15%)**
+- `AuthControllerTest`: HTTP 레이어 검증 (@WebMvcTest 사용)
+- 요청/응답 직렬화, HTTP 상태 코드, 입력 검증 에러
+
+**3. 단위 테스트 (5%)**
+- `JwtTokenProviderTest`: JWT 생성/검증 로직
+
+### 테스트 픽스처
+
+재사용 가능한 테스트 데이터 생성 유틸리티로 테스트 코드 간소화:
+- `UserFixture`: User 엔티티 빌더 (verifiedUser, unverifiedUser 등)
+- `RefreshTokenFixture`: RefreshToken 엔티티 빌더 (유효/만료 토큰)
+- `EmailVerificationTokenFixture`: 이메일 인증 토큰 빌더
+
+## 보안 설계
+
+### 비밀번호 암호화
+- **알고리즘:** BCrypt
+- **Strength:** 프로덕션 10, 테스트 4 (성능 최적화)
+- **설정:** `application.yml` (프로덕션), `application-test.yml` (테스트)
+
+### JWT 보안
+- **서명 알고리즘:** HMAC SHA-256
+- **Secret Key:** 환경변수 또는 설정 파일에서 주입
+- **최소 키 길이:** 256 bits 이상 권장
+
+### Refresh Token 보안
+- **저장소:** PostgreSQL 데이터베이스
+- **검증 전략:** JWT 서명 검증 + DB 일치 여부 이중 체크
+- **디바이스 바인딩:** deviceId를 통한 디바이스 소유권 검증
+- **재사용 방지:** 만료된 토큰 재사용 차단
+
+### 다중 디바이스 보안
+- 각 디바이스별 독립적인 Refresh Token 발급
+- deviceId 불일치 시 InvalidRefreshTokenException 발생
+- 토큰 도용 시나리오 방지 (deviceId 검증)
+
+## 다중 디바이스 로그인 구현
+
+### 데이터베이스 스키마
+
+refresh_tokens 테이블에 `(user_id, device_id)` 복합 유니크 제약 조건 적용
+
+### 시나리오별 동작
+
+**시나리오 1: 새 디바이스 로그인**
+- 사용자가 새로운 디바이스에서 로그인
+- DB에 새로운 RefreshToken 레코드 INSERT
+- 기존 디바이스의 세션은 영향받지 않음
+
+**시나리오 2: 기존 디바이스 재로그인**
+- 사용자가 같은 디바이스에서 재로그인
+- 기존 RefreshToken 레코드 UPDATE (token, expiresAt 갱신)
+- DELETE + INSERT가 아닌 UPDATE로 처리하여 트랜잭션 안정성 확보
+
+**시나리오 3: 다른 디바이스 추가 로그인**
+- 사용자가 여러 디바이스에서 동시 로그인
+- 각 디바이스별 독립적인 RefreshToken 유지
+- 한 디바이스의 로그아웃이 다른 디바이스에 영향 없음
+
+## 구성 파일
+
+### application.yml (프로덕션)
+- JWT secret key 설정 (환경변수 사용 권장)
+- Access Token 만료 시간: 3600000ms (1시간)
+- Refresh Token 만료 시간: 2592000000ms (30일)
+- BCrypt strength: 10
+
+### application-test.yml (테스트)
+- BCrypt strength: 4 (테스트 실행 속도 향상)
+- 기타 설정은 프로덕션과 동일
+
+## 향후 개선 사항
+
+**1. 인증 필터/인터셉터 (별도 태스크)**
+- JWT 기반 인증 필터 구현
+- SecurityContext에 사용자 정보 저장
+- @AuthenticationPrincipal 지원
+- 공개/보호 엔드포인트 구분
+
+**2. 보안 강화**
+- Refresh Token 암호화 저장
+- Token rotation 구현
+- IP 주소 기반 이상 탐지
+- Rate limiting 적용
+
+**3. 모니터링**
+- 로그인 실패 횟수 추적
+- 의심스러운 활동 감지 및 알림
+- 토큰 사용 패턴 분석
+
+**4. 성능 최적화**
+- Refresh Token 캐싱 (Redis)
+- JWT 블랙리스트 관리
+- DB 쿼리 최적화
+
+## 결론
+
+JWT 기반 인증 시스템이 성공적으로 구현되었으며, 다중 디바이스 로그인, 이메일 인증, 자동 세션 갱신 등 모든 요구사항을 충족합니다. TDD 방식으로 개발되어 높은 테스트 커버리지를 확보했으며, Clean Architecture를 따라 유지보수성과 확장성이 우수합니다.
+
+구체적인 구현 코드는 해당 패키지의 소스 코드를 참조하시기 바랍니다.

--- a/backend/src/main/java/app/aipacemaker/backend/auth/endpoint/AuthController.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/endpoint/AuthController.java
@@ -1,6 +1,8 @@
 package app.aipacemaker.backend.auth.endpoint;
 
+import app.aipacemaker.backend.auth.usecase.LoginUser;
 import app.aipacemaker.backend.auth.usecase.RegisterUser;
+import app.aipacemaker.backend.auth.usecase.RenewAccessToken;
 import app.aipacemaker.backend.auth.usecase.VerifyEmail;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -10,17 +12,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final RegisterUser registerUser;
     private final VerifyEmail verifyEmail;
+    private final LoginUser loginUser;
+    private final RenewAccessToken renewAccessToken;
 
-    @PostMapping
+    @PostMapping("/api/users")
     @ResponseStatus(HttpStatus.CREATED)
     public RegisterResponse createUser(@Valid @RequestBody RegisterRequest request) {
-        RegisterUser.Command command = new RegisterUser.Command(request.email, request.password);
+        RegisterUser.Command command = new RegisterUser.Command(request.name, request.email, request.password);
         RegisterUser.Result result = registerUser.execute(command);
 
         return new RegisterResponse(
@@ -30,7 +33,7 @@ public class AuthController {
         );
     }
 
-    @PostMapping("/verification")
+    @PostMapping("/api/users/verification")
     @ResponseStatus(HttpStatus.OK)
     public VerifyEmailResponse verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
         VerifyEmail.Command command = new VerifyEmail.Command(request.token);
@@ -45,6 +48,9 @@ public class AuthController {
     }
 
     record RegisterRequest(
+            @NotBlank(message = "이름은 필수입니다")
+            String name,
+
             @NotBlank(message = "이메일은 필수입니다")
             @Email(message = "올바른 이메일 형식이 아닙니다")
             String email,
@@ -69,5 +75,58 @@ public class AuthController {
             String email,
             boolean verified,
             String message
+    ) {}
+
+    @PostMapping("/api/auth/login")
+    @ResponseStatus(HttpStatus.OK)
+    public LoginResponse login(@Valid @RequestBody LoginRequest request) {
+        LoginUser.Command command = new LoginUser.Command(request.email, request.password, request.deviceId);
+        LoginUser.Result result = loginUser.execute(command);
+
+        return new LoginResponse(
+                result.userId(),
+                result.email(),
+                result.emailVerified(),
+                result.accessToken(),
+                result.refreshToken()
+        );
+    }
+
+    @PostMapping("/api/auth/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    public RefreshTokenResponse refreshToken(@Valid @RequestBody RefreshTokenRequest request) {
+        RenewAccessToken.Command command = new RenewAccessToken.Command(request.refreshToken);
+        RenewAccessToken.Result result = renewAccessToken.execute(command);
+
+        return new RefreshTokenResponse(result.accessToken());
+    }
+
+    record LoginRequest(
+            @NotBlank(message = "이메일은 필수입니다")
+            @Email(message = "올바른 이메일 형식이 아닙니다")
+            String email,
+
+            @NotBlank(message = "비밀번호는 필수입니다")
+            String password,
+
+            @NotBlank(message = "디바이스 ID는 필수입니다")
+            String deviceId
+    ) {}
+
+    record LoginResponse(
+            Long userId,
+            String email,
+            boolean emailVerified,
+            String accessToken,
+            String refreshToken
+    ) {}
+
+    record RefreshTokenRequest(
+            @NotBlank(message = "Refresh Token은 필수입니다")
+            String refreshToken
+    ) {}
+
+    record RefreshTokenResponse(
+            String accessToken
     ) {}
 }

--- a/backend/src/main/java/app/aipacemaker/backend/auth/endpoint/AuthExceptionHandler.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/endpoint/AuthExceptionHandler.java
@@ -1,8 +1,11 @@
 package app.aipacemaker.backend.auth.endpoint;
 
 import app.aipacemaker.backend.auth.model.exception.DuplicateEmailException;
+import app.aipacemaker.backend.auth.model.exception.ExpiredRefreshTokenException;
 import app.aipacemaker.backend.auth.model.exception.ExpiredVerificationTokenException;
+import app.aipacemaker.backend.auth.model.exception.InvalidCredentialsException;
 import app.aipacemaker.backend.auth.model.exception.InvalidPasswordException;
+import app.aipacemaker.backend.auth.model.exception.InvalidRefreshTokenException;
 import app.aipacemaker.backend.auth.model.exception.InvalidVerificationTokenException;
 import app.aipacemaker.backend.auth.model.exception.UserNotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +42,15 @@ public class AuthExceptionHandler {
         log.warn("리소스 없음: {}", e.getMessage());
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
         problemDetail.setTitle("리소스를 찾을 수 없음");
+        return problemDetail;
+    }
+
+    // 인증 실패 예외 (Unauthorized)
+    @ExceptionHandler({InvalidCredentialsException.class, InvalidRefreshTokenException.class, ExpiredRefreshTokenException.class})
+    public ProblemDetail handleUnauthorizedException(RuntimeException e) {
+        log.warn("인증 실패: {}", e.getMessage());
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, e.getMessage());
+        problemDetail.setTitle("인증 실패");
         return problemDetail;
     }
 }

--- a/backend/src/main/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProvider.java
@@ -1,0 +1,119 @@
+package app.aipacemaker.backend.auth.infrastructure;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiry;
+    private final long refreshTokenExpiry;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiry}") long accessTokenExpiry,
+            @Value("${jwt.refresh-token-expiry}") long refreshTokenExpiry
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiry = accessTokenExpiry;
+        this.refreshTokenExpiry = refreshTokenExpiry;
+    }
+
+    /**
+     * Access Token 생성
+     */
+    public String generateAccessToken(Long userId, String email) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + accessTokenExpiry);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("email", email)
+                .claim("type", "access")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성
+     */
+    public String generateRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + refreshTokenExpiry);
+
+        return Jwts.builder()
+                .subject(userId.toString())
+                .claim("type", "refresh")
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /**
+     * 토큰 검증
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.debug("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 토큰에서 userId 추출
+     */
+    public Long extractUserId(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * 토큰에서 email 추출
+     */
+    public String extractEmail(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("email", String.class);
+    }
+
+    /**
+     * 토큰 만료 시간 추출
+     */
+    public LocalDateTime getExpirationTime(String token) {
+        Claims claims = parseClaims(token);
+        Date expiration = claims.getExpiration();
+        return Instant.ofEpochMilli(expiration.getTime())
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProvider.java
@@ -53,13 +53,14 @@ public class JwtTokenProvider {
     /**
      * Refresh Token 생성
      */
-    public String generateRefreshToken(Long userId) {
+    public String generateRefreshToken(Long userId, String deviceId) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + refreshTokenExpiry);
 
         return Jwts.builder()
                 .subject(userId.toString())
                 .claim("type", "refresh")
+                .claim("deviceId", deviceId)
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(secretKey)
@@ -96,6 +97,14 @@ public class JwtTokenProvider {
     public String extractEmail(String token) {
         Claims claims = parseClaims(token);
         return claims.get("email", String.class);
+    }
+
+    /**
+     * 토큰에서 deviceId 추출
+     */
+    public String extractDeviceId(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("deviceId", String.class);
     }
 
     /**

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/EmailVerificationTokenRepository.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/EmailVerificationTokenRepository.java
@@ -1,10 +1,10 @@
 package app.aipacemaker.backend.auth.model;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 
-public interface EmailVerificationTokenRepository {
-    EmailVerificationToken save(EmailVerificationToken token);
-    Optional<EmailVerificationToken> findById(Long id);
+public interface EmailVerificationTokenRepository extends JpaRepository<EmailVerificationToken, Long> {
     Optional<EmailVerificationToken> findByToken(String token);
     void deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshToken.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshToken.java
@@ -1,0 +1,42 @@
+package app.aipacemaker.backend.auth.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens", indexes = {
+        @Index(name = "idx_refresh_token", columnList = "token")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    private Long userId;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshToken.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshToken.java
@@ -9,17 +9,25 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "refresh_tokens", indexes = {
-        @Index(name = "idx_refresh_token", columnList = "token")
-})
+@Table(name = "refresh_tokens",
+       uniqueConstraints = {
+           @UniqueConstraint(name = "uk_user_device", columnNames = {"userId", "deviceId"})
+       })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
     private Long userId;
 
-    @Column(nullable = false, unique = true, length = 500)
+    @Column(nullable = false, length = 100)
+    private String deviceId;
+
+    @Column(nullable = false, length = 500)
     private String token;
 
     @Column(nullable = false)
@@ -29,8 +37,9 @@ public class RefreshToken {
     private LocalDateTime createdAt;
 
     @Builder
-    public RefreshToken(Long userId, String token, LocalDateTime expiresAt) {
+    public RefreshToken(Long userId, String deviceId, String token, LocalDateTime expiresAt) {
         this.userId = userId;
+        this.deviceId = deviceId;
         this.token = token;
         this.expiresAt = expiresAt;
         this.createdAt = LocalDateTime.now();
@@ -38,5 +47,10 @@ public class RefreshToken {
 
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void updateToken(String newToken, LocalDateTime newExpiresAt) {
+        this.token = newToken;
+        this.expiresAt = newExpiresAt;
     }
 }

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshTokenRepository.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package app.aipacemaker.backend.auth.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByToken(String token);
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshTokenRepository.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/RefreshTokenRepository.java
@@ -6,5 +6,7 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
+    Optional<RefreshToken> findByUserIdAndDeviceId(Long userId, String deviceId);
     void deleteByToken(String token);
+    void deleteByUserIdAndDeviceId(Long userId, String deviceId);
 }

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/User.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/User.java
@@ -18,6 +18,9 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 100)
+    private String name;
+
     @Column(nullable = false, unique = true)
     private String email;
 
@@ -31,7 +34,8 @@ public class User {
     private LocalDateTime createdAt;
 
     @Builder
-    public User(String email, String password, boolean emailVerified) {
+    public User(String name, String email, String password, boolean emailVerified) {
+        this.name = name;
         this.email = email;
         this.password = password;
         this.emailVerified = emailVerified;

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/UserRepository.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/UserRepository.java
@@ -1,10 +1,10 @@
 package app.aipacemaker.backend.auth.model;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 
-public interface UserRepository {
-    User save(User user);
-    Optional<User> findById(Long id);
+public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
 }

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/EmailNotVerifiedException.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/EmailNotVerifiedException.java
@@ -1,0 +1,7 @@
+package app.aipacemaker.backend.auth.model.exception;
+
+public class EmailNotVerifiedException extends RuntimeException {
+    public EmailNotVerifiedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/ExpiredRefreshTokenException.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/ExpiredRefreshTokenException.java
@@ -1,0 +1,7 @@
+package app.aipacemaker.backend.auth.model.exception;
+
+public class ExpiredRefreshTokenException extends RuntimeException {
+    public ExpiredRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/InvalidCredentialsException.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package app.aipacemaker.backend.auth.model.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/InvalidRefreshTokenException.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/model/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package app.aipacemaker.backend.auth.model.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+    public InvalidRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/usecase/LoginUser.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/usecase/LoginUser.java
@@ -1,0 +1,83 @@
+package app.aipacemaker.backend.auth.usecase;
+
+import app.aipacemaker.backend.auth.infrastructure.JwtTokenProvider;
+import app.aipacemaker.backend.auth.model.RefreshToken;
+import app.aipacemaker.backend.auth.model.RefreshTokenRepository;
+import app.aipacemaker.backend.auth.model.User;
+import app.aipacemaker.backend.auth.model.UserRepository;
+import app.aipacemaker.backend.auth.model.exception.InvalidCredentialsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LoginUser {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    @Value("${jwt.refresh-token-expiry}")
+    private long refreshTokenExpiry;
+
+    @Transactional
+    public Result execute(Command command) {
+        // 1. 사용자 존재 여부 확인
+        User user = userRepository.findByEmail(command.email)
+                .orElseThrow(() -> new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(command.password, user.getPassword())) {
+            throw new InvalidCredentialsException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        // 3. Access Token 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getEmail());
+
+        // 4. Refresh Token 생성 (deviceId 포함)
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId(), command.deviceId);
+
+        // 5. 기존 Refresh Token 조회 및 갱신 또는 신규 생성
+        refreshTokenRepository.findByUserIdAndDeviceId(user.getId(), command.deviceId)
+                .ifPresentOrElse(
+                        existingToken -> {
+                            // 기존 토큰 업데이트
+                            existingToken.updateToken(refreshToken, LocalDateTime.now().plusSeconds(refreshTokenExpiry / 1000));
+                        },
+                        () -> {
+                            // 신규 토큰 생성
+                            RefreshToken newRefreshToken = RefreshToken.builder()
+                                    .userId(user.getId())
+                                    .deviceId(command.deviceId)
+                                    .token(refreshToken)
+                                    .expiresAt(LocalDateTime.now().plusSeconds(refreshTokenExpiry / 1000))
+                                    .build();
+                            refreshTokenRepository.save(newRefreshToken);
+                        }
+                );
+
+        return new Result(
+                user.getId(),
+                user.getEmail(),
+                user.isEmailVerified(),
+                accessToken,
+                refreshToken
+        );
+    }
+
+    public record Command(String email, String password, String deviceId) {}
+
+    public record Result(
+            Long userId,
+            String email,
+            boolean emailVerified,
+            String accessToken,
+            String refreshToken
+    ) {}
+}

--- a/backend/src/main/java/app/aipacemaker/backend/auth/usecase/RegisterUser.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/usecase/RegisterUser.java
@@ -38,6 +38,7 @@ public class RegisterUser {
         // 3. 비밀번호 암호화 및 사용자 저장
         String encodedPassword = passwordEncoder.encode(command.password);
         User user = User.builder()
+                .name(command.name)
                 .email(command.email)
                 .password(encodedPassword)
                 .emailVerified(false)
@@ -63,7 +64,7 @@ public class RegisterUser {
         return new Result(savedUser.getId(), savedUser.getEmail(), true);
     }
 
-    public record Command(String email, String password) {}
+    public record Command(String name, String email, String password) {}
 
     public record Result(Long userId, String email, boolean verificationTokenCreated) {}
 }

--- a/backend/src/main/java/app/aipacemaker/backend/auth/usecase/RenewAccessToken.java
+++ b/backend/src/main/java/app/aipacemaker/backend/auth/usecase/RenewAccessToken.java
@@ -1,0 +1,61 @@
+package app.aipacemaker.backend.auth.usecase;
+
+import app.aipacemaker.backend.auth.infrastructure.JwtTokenProvider;
+import app.aipacemaker.backend.auth.model.RefreshToken;
+import app.aipacemaker.backend.auth.model.RefreshTokenRepository;
+import app.aipacemaker.backend.auth.model.User;
+import app.aipacemaker.backend.auth.model.UserRepository;
+import app.aipacemaker.backend.auth.model.exception.ExpiredRefreshTokenException;
+import app.aipacemaker.backend.auth.model.exception.InvalidRefreshTokenException;
+import app.aipacemaker.backend.auth.model.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RenewAccessToken {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional(readOnly = true)
+    public Result execute(Command command) {
+        // 1. Refresh Token 형식 검증
+        if (!jwtTokenProvider.validateToken(command.refreshToken)) {
+            throw new InvalidRefreshTokenException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        // 2. Refresh Token에서 userId와 deviceId 추출
+        Long userId = jwtTokenProvider.extractUserId(command.refreshToken);
+        String deviceId = jwtTokenProvider.extractDeviceId(command.refreshToken);
+
+        // 3. DB에서 Refresh Token 조회
+        RefreshToken storedToken = refreshTokenRepository.findByUserIdAndDeviceId(userId, deviceId)
+                .orElseThrow(() -> new InvalidRefreshTokenException("유효하지 않은 Refresh Token입니다."));
+
+        // 4. 토큰 일치 여부 확인
+        if (!storedToken.getToken().equals(command.refreshToken)) {
+            throw new InvalidRefreshTokenException("유효하지 않은 Refresh Token입니다.");
+        }
+
+        // 5. 만료 여부 확인
+        if (storedToken.isExpired()) {
+            throw new ExpiredRefreshTokenException("만료된 Refresh Token입니다.");
+        }
+
+        // 6. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+        // 7. 새로운 Access Token 발급
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getEmail());
+
+        return new Result(newAccessToken);
+    }
+
+    public record Command(String refreshToken) {}
+
+    public record Result(String accessToken) {}
+}

--- a/backend/src/main/java/app/aipacemaker/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/app/aipacemaker/backend/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package app.aipacemaker.backend.config.security;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,9 +12,12 @@ import org.springframework.security.web.SecurityFilterChain;
 @EnableWebSecurity
 public class SecurityConfig {
 
+    @Value("${security.bcrypt.strength:10}")
+    private int bcryptStrength;
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        return new BCryptPasswordEncoder(bcryptStrength);
     }
 
     @Bean

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -56,3 +56,7 @@ jwt:
   secret: ${JWT_SECRET:default-secret-key-for-development-only-must-be-at-least-256-bits-long}
   access-token-expiry: 3600000    # 1시간 (milliseconds)
   refresh-token-expiry: 2592000000 # 30일 (milliseconds)
+
+security:
+  bcrypt:
+    strength: 10  # BCrypt 암호화 강도 (4-31, 기본값 10)

--- a/backend/src/test/java/app/aipacemaker/backend/auth/fixture/EmailVerificationTokenFixture.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/fixture/EmailVerificationTokenFixture.java
@@ -1,0 +1,40 @@
+package app.aipacemaker.backend.auth.fixture;
+
+import app.aipacemaker.backend.auth.model.EmailVerificationToken;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * EmailVerificationToken 엔티티 테스트 픽스처
+ */
+public class EmailVerificationTokenFixture {
+
+    public static EmailVerificationToken.EmailVerificationTokenBuilder defaultToken(Long userId) {
+        return EmailVerificationToken.builder()
+                .userId(userId)
+                .token(UUID.randomUUID().toString())
+                .expiresAt(LocalDateTime.now().plusHours(24));
+    }
+
+    public static EmailVerificationToken.EmailVerificationTokenBuilder expiredToken(Long userId) {
+        return EmailVerificationToken.builder()
+                .userId(userId)
+                .token(UUID.randomUUID().toString())
+                .expiresAt(LocalDateTime.now().minusHours(1));
+    }
+
+    public static EmailVerificationToken.EmailVerificationTokenBuilder withToken(Long userId, String token) {
+        return EmailVerificationToken.builder()
+                .userId(userId)
+                .token(token)
+                .expiresAt(LocalDateTime.now().plusHours(24));
+    }
+
+    public static EmailVerificationToken.EmailVerificationTokenBuilder withExpiresAt(Long userId, String token, LocalDateTime expiresAt) {
+        return EmailVerificationToken.builder()
+                .userId(userId)
+                .token(token)
+                .expiresAt(expiresAt);
+    }
+}

--- a/backend/src/test/java/app/aipacemaker/backend/auth/fixture/RefreshTokenFixture.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/fixture/RefreshTokenFixture.java
@@ -1,0 +1,35 @@
+package app.aipacemaker.backend.auth.fixture;
+
+import app.aipacemaker.backend.auth.model.RefreshToken;
+
+import java.time.LocalDateTime;
+
+/**
+ * RefreshToken 엔티티 테스트 픽스처
+ */
+public class RefreshTokenFixture {
+
+    public static RefreshToken.RefreshTokenBuilder defaultRefreshToken(Long userId, String deviceId, String token) {
+        return RefreshToken.builder()
+                .userId(userId)
+                .deviceId(deviceId)
+                .token(token)
+                .expiresAt(LocalDateTime.now().plusDays(30));
+    }
+
+    public static RefreshToken.RefreshTokenBuilder expiredRefreshToken(Long userId, String deviceId, String token) {
+        return RefreshToken.builder()
+                .userId(userId)
+                .deviceId(deviceId)
+                .token(token)
+                .expiresAt(LocalDateTime.now().minusDays(1));
+    }
+
+    public static RefreshToken.RefreshTokenBuilder withExpiresAt(Long userId, String deviceId, String token, LocalDateTime expiresAt) {
+        return RefreshToken.builder()
+                .userId(userId)
+                .deviceId(deviceId)
+                .token(token)
+                .expiresAt(expiresAt);
+    }
+}

--- a/backend/src/test/java/app/aipacemaker/backend/auth/fixture/UserFixture.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/fixture/UserFixture.java
@@ -1,0 +1,45 @@
+package app.aipacemaker.backend.auth.fixture;
+
+import app.aipacemaker.backend.auth.model.User;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * User 엔티티 테스트 픽스처
+ */
+public class UserFixture {
+
+    private static final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder(4);
+
+    public static User.UserBuilder defaultUser() {
+        return User.builder()
+                .name("테스트유저")
+                .email("test@example.com")
+                .password(passwordEncoder.encode("password123"))
+                .emailVerified(false);
+    }
+
+    public static User.UserBuilder verifiedUser() {
+        return defaultUser()
+                .emailVerified(true);
+    }
+
+    public static User.UserBuilder unverifiedUser() {
+        return defaultUser()
+                .emailVerified(false);
+    }
+
+    public static User.UserBuilder withName(String name) {
+        return defaultUser()
+                .name(name);
+    }
+
+    public static User.UserBuilder withEmail(String email) {
+        return defaultUser()
+                .email(email);
+    }
+
+    public static User.UserBuilder withPassword(String rawPassword) {
+        return defaultUser()
+                .password(passwordEncoder.encode(rawPassword));
+    }
+}

--- a/backend/src/test/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProviderTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProviderTest.java
@@ -1,0 +1,165 @@
+package app.aipacemaker.backend.auth.infrastructure;
+
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("JWT 토큰 생성 및 검증 단위 테스트")
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 고정 설정값
+        String secret = "test-secret-key-for-unit-testing-must-be-at-least-256-bits-long-to-satisfy-hmac-sha-256";
+        long accessTokenExpiry = 3600000L;  // 1시간
+        long refreshTokenExpiry = 2592000000L; // 30일
+
+        jwtTokenProvider = new JwtTokenProvider(secret, accessTokenExpiry, refreshTokenExpiry);
+    }
+
+    @Test
+    @DisplayName("Access Token을 생성하면 유효한 JWT 토큰이 반환된다")
+    void generateAccessToken() {
+        // given
+        Long userId = 1L;
+        String email = "test@example.com";
+
+        // when
+        String token = jwtTokenProvider.generateAccessToken(userId, email);
+
+        // then
+        assertThat(token).isNotNull().isNotEmpty();
+        assertThat(token.split("\\.")).hasSize(3); // JWT는 header.payload.signature 구조
+    }
+
+    @Test
+    @DisplayName("Refresh Token을 생성하면 유효한 JWT 토큰이 반환된다")
+    void generateRefreshToken() {
+        // given
+        Long userId = 1L;
+
+        // when
+        String token = jwtTokenProvider.generateRefreshToken(userId);
+
+        // then
+        assertThat(token).isNotNull().isNotEmpty();
+        assertThat(token.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("유효한 Access Token에서 userId를 추출하면 원본 userId가 반환된다")
+    void extractUserIdFromAccessToken() {
+        // given
+        Long userId = 123L;
+        String email = "user@example.com";
+        String token = jwtTokenProvider.generateAccessToken(userId, email);
+
+        // when
+        Long extractedUserId = jwtTokenProvider.extractUserId(token);
+
+        // then
+        assertThat(extractedUserId).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("유효한 Access Token에서 email을 추출하면 원본 email이 반환된다")
+    void extractEmailFromAccessToken() {
+        // given
+        Long userId = 123L;
+        String email = "user@example.com";
+        String token = jwtTokenProvider.generateAccessToken(userId, email);
+
+        // when
+        String extractedEmail = jwtTokenProvider.extractEmail(token);
+
+        // then
+        assertThat(extractedEmail).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("유효한 토큰을 검증하면 true를 반환한다")
+    void validateValidToken() {
+        // given
+        String token = jwtTokenProvider.generateAccessToken(1L, "test@example.com");
+
+        // when
+        boolean isValid = jwtTokenProvider.validateToken(token);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰을 검증하면 false를 반환한다")
+    void validateExpiredToken() {
+        // given: 즉시 만료되는 토큰 생성
+        JwtTokenProvider shortLivedProvider = new JwtTokenProvider(
+                "test-secret-key-for-unit-testing-must-be-at-least-256-bits-long-to-satisfy-hmac-sha-256",
+                -1000L,  // 음수로 설정하여 즉시 만료
+                1000L
+        );
+        String token = shortLivedProvider.generateAccessToken(1L, "test@example.com");
+
+        // when
+        boolean isValid = jwtTokenProvider.validateToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 토큰을 검증하면 false를 반환한다")
+    void validateMalformedToken() {
+        // given
+        String malformedToken = "invalid.token.format";
+
+        // when
+        boolean isValid = jwtTokenProvider.validateToken(malformedToken);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("잘못된 서명의 토큰을 검증하면 false를 반환한다")
+    void validateTokenWithWrongSignature() {
+        // given: 다른 secret으로 생성된 토큰
+        JwtTokenProvider differentProvider = new JwtTokenProvider(
+                "different-secret-key-for-testing-must-be-at-least-256-bits-long-to-satisfy-hmac-sha",
+                3600000L,
+                2592000000L
+        );
+        String token = differentProvider.generateAccessToken(1L, "test@example.com");
+
+        // when
+        boolean isValid = jwtTokenProvider.validateToken(token);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("Access Token의 만료 시간을 추출하면 발급 시간으로부터 1시간 후이다")
+    void getExpirationTimeOfAccessToken() {
+        // given
+        LocalDateTime beforeCreation = LocalDateTime.now();
+        String token = jwtTokenProvider.generateAccessToken(1L, "test@example.com");
+        LocalDateTime afterCreation = LocalDateTime.now();
+
+        // when
+        LocalDateTime expirationTime = jwtTokenProvider.getExpirationTime(token);
+
+        // then: 발급 시간 + 1시간 범위 내에 있어야 함
+        LocalDateTime expectedMin = beforeCreation.plusHours(1).minusSeconds(1);
+        LocalDateTime expectedMax = afterCreation.plusHours(1).plusSeconds(1);
+        assertThat(expirationTime).isBetween(expectedMin, expectedMax);
+    }
+}

--- a/backend/src/test/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProviderTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/infrastructure/JwtTokenProviderTest.java
@@ -45,13 +45,45 @@ class JwtTokenProviderTest {
     void generateRefreshToken() {
         // given
         Long userId = 1L;
+        String deviceId = "test-device";
 
         // when
-        String token = jwtTokenProvider.generateRefreshToken(userId);
+        String token = jwtTokenProvider.generateRefreshToken(userId, deviceId);
 
         // then
         assertThat(token).isNotNull().isNotEmpty();
         assertThat(token.split("\\.")).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("다른 deviceId로 Refresh Token을 생성하면 다른 토큰이 반환된다")
+    void generateDifferentRefreshTokensWithDifferentDevices() {
+        // given
+        Long userId = 1L;
+        String deviceId1 = "device-1";
+        String deviceId2 = "device-2";
+
+        // when
+        String token1 = jwtTokenProvider.generateRefreshToken(userId, deviceId1);
+        String token2 = jwtTokenProvider.generateRefreshToken(userId, deviceId2);
+
+        // then: deviceId가 다르므로 토큰도 달라야 함
+        assertThat(token1).isNotEqualTo(token2);
+    }
+
+    @Test
+    @DisplayName("유효한 Refresh Token에서 deviceId를 추출하면 원본 deviceId가 반환된다")
+    void extractDeviceIdFromRefreshToken() {
+        // given
+        Long userId = 1L;
+        String deviceId = "mobile-device-001";
+        String token = jwtTokenProvider.generateRefreshToken(userId, deviceId);
+
+        // when
+        String extractedDeviceId = jwtTokenProvider.extractDeviceId(token);
+
+        // then
+        assertThat(extractedDeviceId).isEqualTo(deviceId);
     }
 
     @Test

--- a/backend/src/test/java/app/aipacemaker/backend/auth/usecase/LoginUserTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/usecase/LoginUserTest.java
@@ -1,6 +1,7 @@
 package app.aipacemaker.backend.auth.usecase;
 
 import app.aipacemaker.backend.BaseIntegrationTest;
+import app.aipacemaker.backend.auth.fixture.UserFixture;
 import app.aipacemaker.backend.auth.infrastructure.JwtTokenProvider;
 import app.aipacemaker.backend.auth.model.RefreshToken;
 import app.aipacemaker.backend.auth.model.RefreshTokenRepository;
@@ -47,13 +48,10 @@ class LoginUserTest extends BaseIntegrationTest {
         // given: 이메일 인증된 사용자
         String email = "verified@example.com";
         String rawPassword = "password123";
-        String encodedPassword = passwordEncoder.encode(rawPassword);
 
-        User user = User.builder()
-                .name("테스트유저")
+        User user = UserFixture.verifiedUser()
                 .email(email)
-                .password(encodedPassword)
-                .emailVerified(true)
+                .password(passwordEncoder.encode(rawPassword))
                 .build();
         User savedUser = userRepository.save(user);
 
@@ -89,13 +87,11 @@ class LoginUserTest extends BaseIntegrationTest {
         // given: 이메일 미인증 사용자
         String email = "unverified@example.com";
         String rawPassword = "password123";
-        String encodedPassword = passwordEncoder.encode(rawPassword);
 
-        User user = User.builder()
+        User user = UserFixture.unverifiedUser()
                 .name("미인증유저")
                 .email(email)
-                .password(encodedPassword)
-                .emailVerified(false)
+                .password(passwordEncoder.encode(rawPassword))
                 .build();
         User savedUser = userRepository.save(user);
 
@@ -121,11 +117,9 @@ class LoginUserTest extends BaseIntegrationTest {
         String correctPassword = "password123";
         String encodedPassword = passwordEncoder.encode(correctPassword);
 
-        User user = User.builder()
-                .name("테스트유저")
+        User user = UserFixture.verifiedUser()
                 .email(email)
-                .password(encodedPassword)
-                .emailVerified(true)
+                .password(passwordEncoder.encode(correctPassword))
                 .build();
         userRepository.save(user);
 
@@ -158,13 +152,10 @@ class LoginUserTest extends BaseIntegrationTest {
         // given: 이메일 인증된 사용자
         String email = "user@example.com";
         String rawPassword = "password123";
-        String encodedPassword = passwordEncoder.encode(rawPassword);
 
-        User user = User.builder()
-                .name("테스트유저")
+        User user = UserFixture.verifiedUser()
                 .email(email)
-                .password(encodedPassword)
-                .emailVerified(true)
+                .password(passwordEncoder.encode(rawPassword))
                 .build();
         User savedUser = userRepository.save(user);
 
@@ -194,13 +185,10 @@ class LoginUserTest extends BaseIntegrationTest {
         // given: 이메일 인증된 사용자
         String email = "user@example.com";
         String rawPassword = "password123";
-        String encodedPassword = passwordEncoder.encode(rawPassword);
 
-        User user = User.builder()
-                .name("테스트유저")
+        User user = UserFixture.verifiedUser()
                 .email(email)
-                .password(encodedPassword)
-                .emailVerified(true)
+                .password(passwordEncoder.encode(rawPassword))
                 .build();
         User savedUser = userRepository.save(user);
 

--- a/backend/src/test/java/app/aipacemaker/backend/auth/usecase/LoginUserTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/usecase/LoginUserTest.java
@@ -50,6 +50,7 @@ class LoginUserTest extends BaseIntegrationTest {
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
         User user = User.builder()
+                .name("테스트유저")
                 .email(email)
                 .password(encodedPassword)
                 .emailVerified(true)
@@ -91,6 +92,7 @@ class LoginUserTest extends BaseIntegrationTest {
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
         User user = User.builder()
+                .name("미인증유저")
                 .email(email)
                 .password(encodedPassword)
                 .emailVerified(false)
@@ -120,6 +122,7 @@ class LoginUserTest extends BaseIntegrationTest {
         String encodedPassword = passwordEncoder.encode(correctPassword);
 
         User user = User.builder()
+                .name("테스트유저")
                 .email(email)
                 .password(encodedPassword)
                 .emailVerified(true)
@@ -158,6 +161,7 @@ class LoginUserTest extends BaseIntegrationTest {
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
         User user = User.builder()
+                .name("테스트유저")
                 .email(email)
                 .password(encodedPassword)
                 .emailVerified(true)
@@ -193,6 +197,7 @@ class LoginUserTest extends BaseIntegrationTest {
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
         User user = User.builder()
+                .name("테스트유저")
                 .email(email)
                 .password(encodedPassword)
                 .emailVerified(true)

--- a/backend/src/test/java/app/aipacemaker/backend/auth/usecase/LoginUserTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/usecase/LoginUserTest.java
@@ -1,0 +1,221 @@
+package app.aipacemaker.backend.auth.usecase;
+
+import app.aipacemaker.backend.BaseIntegrationTest;
+import app.aipacemaker.backend.auth.infrastructure.JwtTokenProvider;
+import app.aipacemaker.backend.auth.model.RefreshToken;
+import app.aipacemaker.backend.auth.model.RefreshTokenRepository;
+import app.aipacemaker.backend.auth.model.User;
+import app.aipacemaker.backend.auth.model.UserRepository;
+import app.aipacemaker.backend.auth.model.exception.InvalidCredentialsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 로그인 Event-Driven 통합 테스트
+ *
+ * 테스트 범위:
+ * LoginUser UseCase → JWT 토큰 발급 → Refresh Token DB 저장
+ */
+@DisplayName("로그인 통합 테스트")
+class LoginUserTest extends BaseIntegrationTest {
+
+    @Autowired
+    private LoginUser loginUser;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("유효한 이메일과 비밀번호로 로그인하면 Access Token과 Refresh Token이 발급되고 Refresh Token이 DB에 저장된다")
+    void successfulLogin() {
+        // given: 이메일 인증된 사용자
+        String email = "verified@example.com";
+        String rawPassword = "password123";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .emailVerified(true)
+                .build();
+        User savedUser = userRepository.save(user);
+
+        String deviceId = "test-device-001";
+        LoginUser.Command command = new LoginUser.Command(email, rawPassword, deviceId);
+
+        // when: 로그인 요청
+        LoginUser.Result result = loginUser.execute(command);
+
+        // then: UseCase 실행 결과 검증
+        assertThat(result.userId()).isEqualTo(savedUser.getId());
+        assertThat(result.email()).isEqualTo(email);
+        assertThat(result.emailVerified()).isTrue();
+        assertThat(result.accessToken()).isNotNull().isNotEmpty();
+        assertThat(result.refreshToken()).isNotNull().isNotEmpty();
+
+        // then: Access Token 검증
+        assertThat(jwtTokenProvider.validateToken(result.accessToken())).isTrue();
+        assertThat(jwtTokenProvider.extractUserId(result.accessToken())).isEqualTo(savedUser.getId());
+        assertThat(jwtTokenProvider.extractEmail(result.accessToken())).isEqualTo(email);
+
+        // then: Refresh Token이 해당 디바이스로 DB에 저장됨
+        Optional<RefreshToken> savedRefreshToken = refreshTokenRepository.findByUserIdAndDeviceId(savedUser.getId(), deviceId);
+        assertThat(savedRefreshToken).isPresent();
+        assertThat(savedRefreshToken.get().getToken()).isEqualTo(result.refreshToken());
+        assertThat(savedRefreshToken.get().getDeviceId()).isEqualTo(deviceId);
+        assertThat(savedRefreshToken.get().isExpired()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이메일 미인증 사용자가 로그인하면 토큰이 발급되고 emailVerified가 false로 반환된다")
+    void loginWithUnverifiedEmail() {
+        // given: 이메일 미인증 사용자
+        String email = "unverified@example.com";
+        String rawPassword = "password123";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .emailVerified(false)
+                .build();
+        User savedUser = userRepository.save(user);
+
+        String deviceId = "test-device-002";
+        LoginUser.Command command = new LoginUser.Command(email, rawPassword, deviceId);
+
+        // when: 로그인 요청
+        LoginUser.Result result = loginUser.execute(command);
+
+        // then: 로그인은 성공하지만 emailVerified가 false
+        assertThat(result.userId()).isEqualTo(savedUser.getId());
+        assertThat(result.email()).isEqualTo(email);
+        assertThat(result.emailVerified()).isFalse();
+        assertThat(result.accessToken()).isNotNull().isNotEmpty();
+        assertThat(result.refreshToken()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 로그인하면 InvalidCredentialsException이 발생한다")
+    void loginWithWrongPassword() {
+        // given: 이메일 인증된 사용자
+        String email = "user@example.com";
+        String correctPassword = "password123";
+        String encodedPassword = passwordEncoder.encode(correctPassword);
+
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .emailVerified(true)
+                .build();
+        userRepository.save(user);
+
+        // given: 잘못된 비밀번호로 로그인 시도
+        String deviceId = "test-device-003";
+        LoginUser.Command command = new LoginUser.Command(email, "wrongPassword", deviceId);
+
+        // when & then: InvalidCredentialsException 발생
+        assertThatThrownBy(() -> loginUser.execute(command))
+                .isInstanceOf(InvalidCredentialsException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 로그인하면 InvalidCredentialsException이 발생한다")
+    void loginWithNonExistentEmail() {
+        // given: 존재하지 않는 이메일
+        String deviceId = "test-device-004";
+        LoginUser.Command command = new LoginUser.Command("nonexistent@example.com", "password123", deviceId);
+
+        // when & then: InvalidCredentialsException 발생
+        assertThatThrownBy(() -> loginUser.execute(command))
+                .isInstanceOf(InvalidCredentialsException.class)
+                .hasMessageContaining("이메일 또는 비밀번호가 올바르지 않습니다");
+    }
+
+    @Test
+    @DisplayName("동일 사용자가 같은 기기에서 다시 로그인하면 해당 기기의 Refresh Token이 새 토큰으로 교체된다")
+    void replaceRefreshTokenOnReLoginSameDevice() {
+        // given: 이메일 인증된 사용자
+        String email = "user@example.com";
+        String rawPassword = "password123";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .emailVerified(true)
+                .build();
+        User savedUser = userRepository.save(user);
+
+        String deviceId = "test-device-005";
+        LoginUser.Command command = new LoginUser.Command(email, rawPassword, deviceId);
+
+        // when: 첫 번째 로그인
+        LoginUser.Result firstLogin = loginUser.execute(command);
+
+        // when: 같은 기기에서 두 번째 로그인
+        LoginUser.Result secondLogin = loginUser.execute(command);
+
+        // then: 두 번째 로그인이 성공적으로 완료됨
+        assertThat(secondLogin.userId()).isEqualTo(savedUser.getId());
+        assertThat(secondLogin.accessToken()).isNotNull().isNotEmpty();
+        assertThat(secondLogin.refreshToken()).isNotNull().isNotEmpty();
+
+        // then: DB에는 해당 기기의 최신 Refresh Token만 존재
+        Optional<RefreshToken> savedRefreshToken = refreshTokenRepository.findByUserIdAndDeviceId(savedUser.getId(), deviceId);
+        assertThat(savedRefreshToken).isPresent();
+        assertThat(savedRefreshToken.get().getToken()).isEqualTo(secondLogin.refreshToken());
+    }
+
+    @Test
+    @DisplayName("동일 사용자가 다른 기기에서 로그인하면 각 기기별로 Refresh Token이 독립적으로 저장된다")
+    void multiDeviceLogin() {
+        // given: 이메일 인증된 사용자
+        String email = "user@example.com";
+        String rawPassword = "password123";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        User user = User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .emailVerified(true)
+                .build();
+        User savedUser = userRepository.save(user);
+
+        String deviceId1 = "device-mobile";
+        String deviceId2 = "device-desktop";
+
+        // when: 첫 번째 기기에서 로그인
+        LoginUser.Result loginDevice1 = loginUser.execute(new LoginUser.Command(email, rawPassword, deviceId1));
+
+        // when: 두 번째 기기에서 로그인
+        LoginUser.Result loginDevice2 = loginUser.execute(new LoginUser.Command(email, rawPassword, deviceId2));
+
+        // then: 각 기기별로 독립적인 Refresh Token 저장됨
+        Optional<RefreshToken> tokenDevice1 = refreshTokenRepository.findByUserIdAndDeviceId(savedUser.getId(), deviceId1);
+        Optional<RefreshToken> tokenDevice2 = refreshTokenRepository.findByUserIdAndDeviceId(savedUser.getId(), deviceId2);
+
+        assertThat(tokenDevice1).isPresent();
+        assertThat(tokenDevice2).isPresent();
+        assertThat(tokenDevice1.get().getToken()).isEqualTo(loginDevice1.refreshToken());
+        assertThat(tokenDevice2.get().getToken()).isEqualTo(loginDevice2.refreshToken());
+        assertThat(tokenDevice1.get().getToken()).isNotEqualTo(tokenDevice2.get().getToken());
+    }
+}

--- a/backend/src/test/java/app/aipacemaker/backend/auth/usecase/RenewAccessTokenTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/usecase/RenewAccessTokenTest.java
@@ -1,0 +1,163 @@
+package app.aipacemaker.backend.auth.usecase;
+
+import app.aipacemaker.backend.BaseIntegrationTest;
+import app.aipacemaker.backend.auth.infrastructure.JwtTokenProvider;
+import app.aipacemaker.backend.auth.model.RefreshToken;
+import app.aipacemaker.backend.auth.model.RefreshTokenRepository;
+import app.aipacemaker.backend.auth.model.User;
+import app.aipacemaker.backend.auth.model.UserRepository;
+import app.aipacemaker.backend.auth.model.exception.ExpiredRefreshTokenException;
+import app.aipacemaker.backend.auth.model.exception.InvalidRefreshTokenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Access Token 갱신 통합 테스트
+ *
+ * 테스트 범위:
+ * RenewAccessToken UseCase → Refresh Token 검증 → 새로운 Access Token 발급
+ */
+@DisplayName("Access Token 갱신 통합 테스트")
+class RenewAccessTokenTest extends BaseIntegrationTest {
+
+    @Autowired
+    private RenewAccessToken renewAccessToken;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("유효한 Refresh Token으로 요청하면 새로운 Access Token이 발급된다")
+    void successfulRefresh() {
+        // given: 사용자 및 유효한 Refresh Token 생성
+        User user = User.builder()
+                .email("user@example.com")
+                .password("encodedPassword")
+                .emailVerified(true)
+                .build();
+        User savedUser = userRepository.save(user);
+
+        String deviceId = "test-device";
+        String refreshTokenString = jwtTokenProvider.generateRefreshToken(savedUser.getId(), deviceId);
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(savedUser.getId())
+                .deviceId(deviceId)
+                .token(refreshTokenString)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+        refreshTokenRepository.save(refreshToken);
+
+        RenewAccessToken.Command command = new RenewAccessToken.Command(refreshTokenString);
+
+        // when: Access Token 갱신 요청
+        RenewAccessToken.Result result = renewAccessToken.execute(command);
+
+        // then: 새로운 Access Token이 발급됨
+        assertThat(result.accessToken()).isNotNull().isNotEmpty();
+        assertThat(jwtTokenProvider.validateToken(result.accessToken())).isTrue();
+        assertThat(jwtTokenProvider.extractUserId(result.accessToken())).isEqualTo(savedUser.getId());
+        assertThat(jwtTokenProvider.extractEmail(result.accessToken())).isEqualTo(savedUser.getEmail());
+    }
+
+    @Test
+    @DisplayName("JWT 형식이 잘못된 Refresh Token으로 요청하면 InvalidRefreshTokenException이 발생한다")
+    void invalidTokenFormat() {
+        // given: 잘못된 형식의 토큰
+        RenewAccessToken.Command command = new RenewAccessToken.Command("invalid.token.format");
+
+        // when & then: InvalidRefreshTokenException 발생
+        assertThatThrownBy(() -> renewAccessToken.execute(command))
+                .isInstanceOf(InvalidRefreshTokenException.class)
+                .hasMessageContaining("유효하지 않은 Refresh Token입니다");
+    }
+
+    @Test
+    @DisplayName("DB에 존재하지 않는 Refresh Token으로 요청하면 InvalidRefreshTokenException이 발생한다")
+    void tokenNotInDatabase() {
+        // given: 유효한 JWT이지만 DB에 없는 토큰
+        String validButNotStoredToken = jwtTokenProvider.generateRefreshToken(999L, "unknown-device");
+        RenewAccessToken.Command command = new RenewAccessToken.Command(validButNotStoredToken);
+
+        // when & then: InvalidRefreshTokenException 발생
+        assertThatThrownBy(() -> renewAccessToken.execute(command))
+                .isInstanceOf(InvalidRefreshTokenException.class)
+                .hasMessageContaining("유효하지 않은 Refresh Token입니다");
+    }
+
+    @Test
+    @DisplayName("만료된 Refresh Token으로 요청하면 ExpiredRefreshTokenException이 발생한다")
+    void expiredToken() {
+        // given: 사용자 및 만료된 Refresh Token 생성
+        User user = User.builder()
+                .email("user@example.com")
+                .password("encodedPassword")
+                .emailVerified(true)
+                .build();
+        User savedUser = userRepository.save(user);
+
+        String deviceId = "test-device";
+        String refreshTokenString = jwtTokenProvider.generateRefreshToken(savedUser.getId(), deviceId);
+
+        RefreshToken expiredToken = RefreshToken.builder()
+                .userId(savedUser.getId())
+                .deviceId(deviceId)
+                .token(refreshTokenString)
+                .expiresAt(LocalDateTime.now().minusDays(1))  // 이미 만료됨
+                .build();
+        refreshTokenRepository.save(expiredToken);
+
+        RenewAccessToken.Command command = new RenewAccessToken.Command(refreshTokenString);
+
+        // when & then: ExpiredRefreshTokenException 발생
+        assertThatThrownBy(() -> renewAccessToken.execute(command))
+                .isInstanceOf(ExpiredRefreshTokenException.class)
+                .hasMessageContaining("만료된 Refresh Token입니다");
+    }
+
+    @Test
+    @DisplayName("다른 기기의 Refresh Token으로 요청하면 deviceId가 일치하지 않아 InvalidRefreshTokenException이 발생한다")
+    void mismatchedDeviceId() {
+        // given: 사용자 및 특정 기기의 Refresh Token 생성
+        User user = User.builder()
+                .email("user@example.com")
+                .password("encodedPassword")
+                .emailVerified(true)
+                .build();
+        User savedUser = userRepository.save(user);
+
+        String actualDeviceId = "device-A";
+        String stolenDeviceId = "device-B";
+
+        // device-A의 토큰 생성 및 저장
+        String refreshTokenString = jwtTokenProvider.generateRefreshToken(savedUser.getId(), actualDeviceId);
+        RefreshToken refreshToken = RefreshToken.builder()
+                .userId(savedUser.getId())
+                .deviceId(actualDeviceId)
+                .token(refreshTokenString)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+        refreshTokenRepository.save(refreshToken);
+
+        // device-B의 토큰 생성 (DB에 저장 안 함, 도용 시나리오)
+        String stolenToken = jwtTokenProvider.generateRefreshToken(savedUser.getId(), stolenDeviceId);
+        RenewAccessToken.Command command = new RenewAccessToken.Command(stolenToken);
+
+        // when & then: InvalidRefreshTokenException 발생
+        assertThatThrownBy(() -> renewAccessToken.execute(command))
+                .isInstanceOf(InvalidRefreshTokenException.class)
+                .hasMessageContaining("유효하지 않은 Refresh Token입니다");
+    }
+}

--- a/backend/src/test/java/app/aipacemaker/backend/auth/usecase/RenewAccessTokenTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/usecase/RenewAccessTokenTest.java
@@ -43,6 +43,7 @@ class RenewAccessTokenTest extends BaseIntegrationTest {
     void successfulRefresh() {
         // given: 사용자 및 유효한 Refresh Token 생성
         User user = User.builder()
+                .name("테스트유저")
                 .email("user@example.com")
                 .password("encodedPassword")
                 .emailVerified(true)
@@ -102,6 +103,7 @@ class RenewAccessTokenTest extends BaseIntegrationTest {
     void expiredToken() {
         // given: 사용자 및 만료된 Refresh Token 생성
         User user = User.builder()
+                .name("테스트유저")
                 .email("user@example.com")
                 .password("encodedPassword")
                 .emailVerified(true)
@@ -132,6 +134,7 @@ class RenewAccessTokenTest extends BaseIntegrationTest {
     void mismatchedDeviceId() {
         // given: 사용자 및 특정 기기의 Refresh Token 생성
         User user = User.builder()
+                .name("테스트유저")
                 .email("user@example.com")
                 .password("encodedPassword")
                 .emailVerified(true)

--- a/backend/src/test/java/app/aipacemaker/backend/auth/usecase/VerifyEmailTest.java
+++ b/backend/src/test/java/app/aipacemaker/backend/auth/usecase/VerifyEmailTest.java
@@ -38,6 +38,7 @@ class VerifyEmailTest extends BaseIntegrationTest {
     void successfulVerification() {
         // given
         User user = User.builder()
+                .name("테스트유저")
                 .email("test@example.com")
                 .password("encodedPassword123")
                 .emailVerified(false)
@@ -77,6 +78,7 @@ class VerifyEmailTest extends BaseIntegrationTest {
     void expiredTokenFails() {
         // given
         User user = User.builder()
+                .name("테스트유저")
                 .email("test@example.com")
                 .password("encodedPassword123")
                 .emailVerified(false)
@@ -114,6 +116,7 @@ class VerifyEmailTest extends BaseIntegrationTest {
     void alreadyVerifiedUserSuccess() {
         // given
         User user = User.builder()
+                .name("인증완료유저")
                 .email("test@example.com")
                 .password("encodedPassword123")
                 .emailVerified(true)

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -33,3 +33,7 @@ decorator:
 logging:
   level:
     net.ttddyy.dsproxy.listener: INFO
+
+security:
+  bcrypt:
+    strength: 4  # 테스트 속도 향상을 위한 최소 강도


### PR DESCRIPTION
# Pull Request

## 변경 사항

JWT 기반 인증 시스템을 구현했습니다. 회원가입(이름, 이메일, 비밀번호), 로그인, Access Token 갱신 기능이 완성되었으며, 다중 디바이스 로그인을 지원합니다.

### 주요 구현 내용

**1. 도메인 모델**
- `User` 엔티티에 `name` 필드 추가 (회원가입 시 필수 입력)
- `RefreshToken` 엔티티 구현 (userId + deviceId 복합 유니크 제약)
- Repository를 JpaRepository로 직접 확장하여 불필요한 어댑터 계층 제거

**2. JWT 인증 시스템**
- JwtTokenProvider: JWT 토큰 생성 및 검증 유틸리티
- Access Token (1시간 유효) + Refresh Token (30일 유효)
- Refresh Token에 deviceId 포함하여 다중 디바이스 지원 및 보안 강화

**3. UseCase 구현**
- `LoginUser`: 로그인 및 토큰 발급 (이메일 미인증 사용자도 로그인 가능)
- `RenewAccessToken`: Refresh Token으로 Access Token 갱신
- 다중 디바이스 지원: 같은 디바이스 재로그인 시 UPDATE, 새 디바이스는 INSERT

**4. API 엔드포인트**
- `POST /api/users`: 회원가입 (이름, 이메일, 비밀번호)
- `POST /api/users/verification`: 이메일 인증
- `POST /api/auth/login`: 로그인 (deviceId 포함)
- `POST /api/auth/refresh`: Access Token 갱신
- `AuthExceptionHandler`: RFC 7807 ProblemDetail 형식으로 인증 에러 처리

**6. 성능 최적화**
- BCrypt 강도를 환경별로 설정 (프로덕션: 10, 테스트: 4)

**7. 문서화**
- API 문서: `backend/src/main/java/app/aipacemaker/backend/auth/docs/api.md`
- 기능 구현 문서: `backend/src/main/java/app/aipacemaker/backend/auth/docs/feature.md`

### 다중 디바이스 로그인 시나리오

**시나리오 1: 새 디바이스 로그인**
- 새로운 디바이스에서 로그인 시 독립적인 RefreshToken INSERT

**시나리오 2: 기존 디바이스 재로그인**
- 같은 디바이스에서 재로그인 시 기존 RefreshToken UPDATE

**시나리오 3: 다중 디바이스 동시 사용**
- 각 디바이스별 독립적인 세션 유지 (한 디바이스 로그아웃이 다른 디바이스에 영향 없음)

### 다음 작업 (별도 이슈)

JWT 인증 필터/인터셉터 구현:
- Spring Security 통합
- HTTP 요청에서 Authorization 헤더 추출 및 검증
- SecurityContext에 인증 정보 설정
- @AuthenticationPrincipal 지원
- 공개/보호 엔드포인트 구분

---

## PR 정보

### 유형:
- [x] 완료 작업 (이슈 종료)

### 이슈 참조:
Closes #20 

---

체크리스트
- [x] 로컬 테스트 완료 (전체 테스트 통과)
- [x] 커밋 메시지 컨벤션 준수
- [x] 불필요한 코드 제거
- [x] 문서 작성 완료 (API 문서, 기능 문서)