### PR TITLE
[완료] Feature: 레이아웃 및 네비게이션 시스템의 전체 구조를 구현

### DIFF
--- a/frontend/src/lib/components/layout/Sidebar.svelte
+++ b/frontend/src/lib/components/layout/Sidebar.svelte
@@ -8,6 +8,20 @@
 	}
 
 	let { isOpen = false, onClose }: Props = $props();
+
+	// ESC 키로 사이드바 닫기
+	$effect(() => {
+		if (!isOpen) return;
+
+		function handleKeydown(event: KeyboardEvent) {
+			if (event.key === 'Escape') {
+				onClose?.();
+			}
+		}
+
+		window.addEventListener('keydown', handleKeydown);
+		return () => window.removeEventListener('keydown', handleKeydown);
+	});
 </script>
 
 <!-- Desktop: 고정 사이드바 -->
@@ -26,6 +40,7 @@
 	<!-- 오버레이 배경 (클릭 시 닫기) -->
 	<button
 		onclick={onClose}
+		onkeydown={(e) => e.key === 'Escape' && onClose?.()}
 		class="lg:hidden fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
 		aria-label="사이드바 닫기"
 		tabindex="-1"
@@ -34,6 +49,9 @@
 	<!-- 사이드바 콘텐츠 -->
 	<aside
 		class="lg:hidden fixed top-16 bottom-0 left-0 w-60 bg-white border-r border-[#E5E5E5] z-50 animate-slide-in"
+		role="dialog"
+		aria-modal="true"
+		aria-label="네비게이션 메뉴"
 	>
 		<nav class="p-4 space-y-1" aria-label="주요 네비게이션">
 			{#each NAV_ITEMS as item}

--- a/frontend/src/lib/components/layout/UserMenu.svelte
+++ b/frontend/src/lib/components/layout/UserMenu.svelte
@@ -30,6 +30,20 @@
 
 	// 사용자 이름의 첫 글자 (아바타 폴백)
 	const initials = $derived(user.name.charAt(0).toUpperCase());
+
+	// ESC 키로 메뉴 닫기
+	$effect(() => {
+		if (!isOpen) return;
+
+		function handleKeydown(event: KeyboardEvent) {
+			if (event.key === 'Escape') {
+				closeMenu();
+			}
+		}
+
+		window.addEventListener('keydown', handleKeydown);
+		return () => window.removeEventListener('keydown', handleKeydown);
+	});
 </script>
 
 <!-- 사용자 메뉴 컨테이너 -->
@@ -82,6 +96,8 @@
 		<!-- 메뉴 콘텐츠 -->
 		<div
 			class="absolute right-0 mt-2 w-56 bg-white rounded-lg shadow-lg border border-[#E5E5E5] py-2 z-50 animate-in fade-in slide-in-from-top"
+			role="menu"
+			aria-orientation="vertical"
 		>
 			<!-- 사용자 정보 -->
 			<div class="px-4 py-3 border-b border-[#E5E5E5]">
@@ -95,6 +111,7 @@
 					href="/app/settings/profile"
 					onclick={closeMenu}
 					class="block px-4 py-2 text-sm text-[#404040] hover:bg-[#F5F5F5] transition-colors"
+					role="menuitem"
 				>
 					프로필
 				</a>
@@ -102,6 +119,7 @@
 					href="/app/settings"
 					onclick={closeMenu}
 					class="block px-4 py-2 text-sm text-[#404040] hover:bg-[#F5F5F5] transition-colors"
+					role="menuitem"
 				>
 					설정
 				</a>
@@ -114,6 +132,7 @@
 			<button
 				onclick={handleLogout}
 				class="w-full text-left px-4 py-2 text-sm text-[#DC2626] hover:bg-[#FEF2F2] transition-colors"
+				role="menuitem"
 			>
 				로그아웃
 			</button>

--- a/frontend/src/lib/components/layout/UserMenu.svelte
+++ b/frontend/src/lib/components/layout/UserMenu.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Avatar from '$lib/components/ui/Avatar.svelte';
 	import type { User } from '$lib/types/navigation';
 
 	interface Props {
@@ -28,9 +29,6 @@
 		}
 	}
 
-	// 사용자 이름의 첫 글자 (아바타 폴백)
-	const initials = $derived(user.name.charAt(0).toUpperCase());
-
 	// ESC 키로 메뉴 닫기
 	$effect(() => {
 		if (!isOpen) return;
@@ -56,15 +54,7 @@
 		aria-expanded={isOpen}
 	>
 		<!-- 아바타 -->
-		<div
-			class="w-8 h-8 rounded-full bg-[#FF6B4A] text-white flex items-center justify-center text-sm font-semibold"
-		>
-			{#if user.avatar}
-				<img src={user.avatar} alt={user.name} class="w-full h-full rounded-full object-cover" />
-			{:else}
-				{initials}
-			{/if}
-		</div>
+		<Avatar src={user.avatar} alt={user.name} fallback={user.name.charAt(0)} size="sm" />
 
 		<!-- 사용자 이름 (모바일에서 숨김) -->
 		<span class="hidden md:inline text-sm font-medium text-[#171717]">
@@ -100,9 +90,12 @@
 			aria-orientation="vertical"
 		>
 			<!-- 사용자 정보 -->
-			<div class="px-4 py-3 border-b border-[#E5E5E5]">
-				<p class="text-sm font-medium text-[#171717]">{user.name}</p>
-				<p class="text-xs text-[#737373] mt-1">{user.email}</p>
+			<div class="px-4 py-3 border-b border-[#E5E5E5] flex items-center gap-3">
+				<Avatar src={user.avatar} alt={user.name} fallback={user.name.charAt(0)} size="md" />
+				<div class="flex-1 min-w-0">
+					<p class="text-sm font-medium text-[#171717] truncate">{user.name}</p>
+					<p class="text-xs text-[#737373] mt-0.5 truncate">{user.email}</p>
+				</div>
 			</div>
 
 			<!-- 메뉴 아이템 -->
@@ -110,18 +103,40 @@
 				<a
 					href="/app/settings/profile"
 					onclick={closeMenu}
-					class="block px-4 py-2 text-sm text-[#404040] hover:bg-[#F5F5F5] transition-colors"
+					class="flex items-center gap-3 px-4 py-2 text-sm text-[#404040] hover:bg-[#F5F5F5] transition-colors"
 					role="menuitem"
 				>
-					프로필
+					<svg class="w-4 h-4 text-[#737373]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+						/>
+					</svg>
+					<span>프로필</span>
 				</a>
 				<a
 					href="/app/settings"
 					onclick={closeMenu}
-					class="block px-4 py-2 text-sm text-[#404040] hover:bg-[#F5F5F5] transition-colors"
+					class="flex items-center gap-3 px-4 py-2 text-sm text-[#404040] hover:bg-[#F5F5F5] transition-colors"
 					role="menuitem"
 				>
-					설정
+					<svg class="w-4 h-4 text-[#737373]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+						/>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+						/>
+					</svg>
+					<span>설정</span>
 				</a>
 			</div>
 
@@ -131,10 +146,18 @@
 			<!-- 로그아웃 -->
 			<button
 				onclick={handleLogout}
-				class="w-full text-left px-4 py-2 text-sm text-[#DC2626] hover:bg-[#FEF2F2] transition-colors"
+				class="w-full flex items-center gap-3 px-4 py-2 text-sm text-[#DC2626] hover:bg-[#FEF2F2] transition-colors"
 				role="menuitem"
 			>
-				로그아웃
+				<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+						d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+					/>
+				</svg>
+				<span>로그아웃</span>
 			</button>
 		</div>
 	{/if}

--- a/frontend/src/lib/components/ui/Avatar.svelte
+++ b/frontend/src/lib/components/ui/Avatar.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	interface Props {
+		src?: string;
+		alt: string;
+		fallback?: string;
+		size?: 'sm' | 'md' | 'lg';
+	}
+
+	let { src, alt, fallback, size = 'md' }: Props = $props();
+
+	// 이미지 로드 실패 시 fallback 표시
+	let imageError = $state(false);
+
+	function handleImageError() {
+		imageError = true;
+	}
+
+	// 사이즈별 클래스
+	const sizeClasses = {
+		sm: 'w-8 h-8 text-sm',
+		md: 'w-10 h-10 text-base',
+		lg: 'w-16 h-16 text-2xl'
+	};
+
+	// fallback 텍스트가 없으면 alt의 첫 글자 사용
+	const displayFallback = $derived(
+		fallback || alt.charAt(0).toUpperCase() || '?'
+	);
+</script>
+
+<div
+	class="rounded-full bg-[#FF6B4A] text-white flex items-center justify-center font-semibold flex-shrink-0 {sizeClasses[size]}"
+	title={alt}
+>
+	{#if src && !imageError}
+		<img
+			{src}
+			{alt}
+			class="w-full h-full rounded-full object-cover"
+			onerror={handleImageError}
+		/>
+	{:else}
+		<span>{displayFallback}</span>
+	{/if}
+</div>

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -1,0 +1,124 @@
+// 사용자 인증 상태를 관리하는 Svelte 5 Runes 기반 스토어
+import type { User } from '$lib/types/navigation';
+
+interface AuthState {
+	user: User | null;
+	isLoading: boolean;
+	isAuthenticated: boolean;
+}
+
+// 초기 상태
+const initialState: AuthState = {
+	user: null,
+	isLoading: true,
+	isAuthenticated: false
+};
+
+// Svelte 5 Runes 기반 인증 스토어
+function createAuthStore() {
+	let state = $state<AuthState>(initialState);
+
+	return {
+		// 읽기 전용 getter
+		get user() {
+			return state.user;
+		},
+		get isLoading() {
+			return state.isLoading;
+		},
+		get isAuthenticated() {
+			return state.isAuthenticated;
+		},
+
+		// 사용자 정보 설정
+		setUser(user: User | null) {
+			state.user = user;
+			state.isAuthenticated = !!user;
+			state.isLoading = false;
+		},
+
+		// 로딩 상태 설정
+		setLoading(loading: boolean) {
+			state.isLoading = loading;
+		},
+
+		// 로그인
+		async login(email: string, password: string) {
+			try {
+				state.isLoading = true;
+
+				const response = await fetch('/api/auth/login', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({ email, password }),
+					credentials: 'include' // HttpOnly Cookie 포함
+				});
+
+				if (!response.ok) {
+					throw new Error('로그인에 실패했습니다.');
+				}
+
+				const data = await response.json();
+
+				// 사용자 정보 저장 (백엔드 응답 구조에 따라 조정 필요)
+				this.setUser({
+					name: data.name || data.username || email.split('@')[0],
+					email: data.email || email,
+					avatar: data.avatar
+				});
+
+				return { success: true };
+			} catch (error) {
+				state.isLoading = false;
+				console.error('로그인 오류:', error);
+				return { success: false, error: '로그인에 실패했습니다.' };
+			}
+		},
+
+		// 로그아웃
+		async logout() {
+			try {
+				await fetch('/api/auth/logout', {
+					method: 'POST',
+					credentials: 'include'
+				});
+			} catch (error) {
+				console.error('로그아웃 오류:', error);
+			} finally {
+				// 로컬 상태 초기화
+				this.setUser(null);
+			}
+		},
+
+		// 현재 사용자 정보 가져오기 (세션 확인)
+		async fetchUser() {
+			try {
+				state.isLoading = true;
+
+				const response = await fetch('/api/auth/me', {
+					credentials: 'include'
+				});
+
+				if (response.ok) {
+					const data = await response.json();
+					this.setUser({
+						name: data.name || data.username || data.email?.split('@')[0] || '사용자',
+						email: data.email,
+						avatar: data.avatar
+					});
+				} else {
+					// 인증 실패 시 사용자 정보 초기화
+					this.setUser(null);
+				}
+			} catch (error) {
+				console.error('사용자 정보 가져오기 오류:', error);
+				this.setUser(null);
+			}
+		}
+	};
+}
+
+// 싱글톤 인스턴스 생성 및 export
+export const authStore = createAuthStore();

--- a/frontend/src/routes/(app)/+layout.svelte
+++ b/frontend/src/routes/(app)/+layout.svelte
@@ -2,18 +2,24 @@
 	import Header from '$lib/components/layout/Header.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import MobileNav from '$lib/components/layout/MobileNav.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import { goto } from '$app/navigation';
 	import '../../app.css';
 
-	let { children } = $props();
+	let { children, data } = $props();
 
 	// 사이드바 열림/닫힘 상태 (모바일/태블릿용)
 	let isSidebarOpen = $state(false);
 
-	// TODO: 실제 사용자 데이터는 인증 스토어에서 가져오기
-	const user = {
-		name: '김성장',
-		email: 'user@example.com'
-	};
+	// +layout.ts에서 로드한 사용자 정보를 authStore에 동기화
+	$effect(() => {
+		if (data.user) {
+			authStore.setUser(data.user);
+		}
+	});
+
+	// authStore에서 사용자 정보 가져오기
+	const user = $derived(authStore.user);
 
 	function toggleSidebar() {
 		isSidebarOpen = !isSidebarOpen;
@@ -23,10 +29,9 @@
 		isSidebarOpen = false;
 	}
 
-	function handleLogout() {
-		// TODO: 실제 로그아웃 로직 구현 (인증 스토어와 연동)
-		console.log('로그아웃');
-		window.location.href = '/login';
+	async function handleLogout() {
+		await authStore.logout();
+		goto('/login');
 	}
 </script>
 

--- a/frontend/src/routes/(app)/+layout.ts
+++ b/frontend/src/routes/(app)/+layout.ts
@@ -1,0 +1,35 @@
+import { redirect } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ fetch, url }) => {
+	try {
+		// 세션 확인: /api/auth/me 엔드포인트 호출
+		const response = await fetch('/api/auth/me', {
+			credentials: 'include'
+		});
+
+		if (!response.ok) {
+			// 인증 실패 시 로그인 페이지로 리디렉션
+			// 현재 URL을 쿼리 파라미터로 저장하여 로그인 후 복귀 가능
+			throw redirect(303, `/login?redirectTo=${encodeURIComponent(url.pathname)}`);
+		}
+
+		const user = await response.json();
+
+		return {
+			user: {
+				name: user.name || user.username || user.email?.split('@')[0] || '사용자',
+				email: user.email,
+				avatar: user.avatar
+			}
+		};
+	} catch (error) {
+		// redirect는 throw되므로 그대로 전파
+		if (error instanceof Response) {
+			throw error;
+		}
+
+		// 기타 에러 시 로그인 페이지로 리디렉션
+		throw redirect(303, `/login?redirectTo=${encodeURIComponent(url.pathname)}`);
+	}
+};


### PR DESCRIPTION
# Pull Request

## 변경 사항

레이아웃 및 네비게이션 시스템의 전체 구조를 구현했습니다. 사용자 인증 상태 관리부터 접근성 개선까지, 프론트엔드의 핵심 인프라를 완성했습니다.

## 주요 구현 내용

### 1. 인증 시스템 구축

- **인증 스토어 (src/lib/stores/auth.svelte.ts)**
  - Svelte 5 Runes 기반 전역 상태 관리
  - HttpOnly Cookie 기반 인증 지원 (Access Token + Refresh Token)
  - login(), logout(), fetchUser() API 연동 함수
- **인증 가드 (src/routes/(app)/+layout.ts)**
  - /api/auth/me 엔드포인트로 세션 확인
  - 미인증 사용자 자동 리디렉션 (/login?redirectTo={원래URL})
  - 로그인 후 원래 페이지로 복귀


### 2. 레이아웃 컴포넌트 통합
- **로그인 전후 레이아웃 분리**
  - (public)/+layout.svelte: 심플 헤더 + 로그인 버튼
  - (app)/+layout.svelte: Header + Sidebar + MobileNav
- **인증 스토어 연동**
  - $effect()로 layout 데이터와 authStore 동기화
  - 하드코딩된 사용자 정보를 실제 인증 상태로 교체
  - 로그아웃 기능을 API와 연결


### 3. 로그인 페이지 개선
- **인증 스토어 연동 및 에러 처리**
- **로그인 성공 시 redirectTo 파라미터로 원래 페이지 복귀**
- **로딩 상태 관리 및 에러 메시지 표시**

### 4. 접근성(A11y) 강화
- **키보드 네비게이션**
  - ESC 키로 사이드바 및 드롭다운 메뉴 닫기
  - $effect()로 이벤트 리스너 등록 및 정리
- **ARIA 속성 추가**
  - Sidebar: role="dialog", aria-modal="true", aria-label
  - UserMenu: role="menu", aria-orientation="vertical", role="menuitem"
  - NavItem: aria-current="page" (활성 메뉴 표시)

### 5. UI 컴포넌트 개선
- **Avatar 컴포넌트 (src/lib/components/ui/Avatar.svelte)**
  - 재사용 가능한 아바타 컴포넌트
  - 이미지 로드 실패 시 fallback 텍스트 (이니셜)
  - 3가지 사이즈 지원 (sm, md, lg)
- **UserMenu 드롭다운 개선**
  - Avatar 컴포넌트 통합
  - 메뉴 아이템에 아이콘 추가 (프로필, 설정, 로그아웃) 
  - 긴 텍스트 처리를 위한 truncate 적용


### 테스트 방법
1. 로그아웃 상태에서 /app/backlog 접근 시 /login으로 리디렉션 확인
2. 로그인 성공 후 원래 페이지(/app/backlog)로 복귀 확인
3. 모바일 환경에서 ESC 키로 사이드바 닫기 확인
4. 사용자 메뉴에서 아바타 및 드롭다운 동작 확인

---

PR 정보
유형:
- [x] 완료 작업 (이슈 종료)
이슈 참조:
Closes #35 

체크리스트
- [x] 로컬 빌드 확인 (npm run build)
- [x] 커밋 메시지 컨벤션 준수
- [x] 명세서(v1.0.0/DS/00-layout-navigation.md) 요구사항 충족
- [x] 반응형 레이아웃 동작 확인 (Mobile/Tablet/Desktop)
- [x] 접근성 기능 테스트 (키보드 네비게이션, ARIA)
