### PR TITLE
[부분 완료] feat: 프론트엔드 인증 시스템 구현

### DIFF
--- a/docs/requirements/auth-api-requirements.md
+++ b/docs/requirements/auth-api-requirements.md
@@ -1,0 +1,318 @@
+# 인증 API 추가 요구사항
+
+**작성일:** 2025-01-16
+**작성자:** Frontend Team
+**상태:** 요청됨
+**우선순위:** 높음
+
+---
+
+## 개요
+
+프론트엔드 인증 시스템 구현 완료 후, 사용자 세션 관리를 위해 다음 두 가지 API가 추가로 필요합니다.
+
+---
+
+## 1. 현재 사용자 정보 조회 API
+
+### 기본 정보
+
+**Endpoint:** `GET /api/auth/me`
+
+**인증:** Required (Access Token via HttpOnly Cookie)
+
+**설명:** 현재 로그인한 사용자의 정보를 반환합니다. 프론트엔드에서 페이지 로드 시 사용자 인증 상태 확인 및 사용자 정보를 가져오는 데 사용됩니다.
+
+### Request
+
+**Headers:**
+```
+Cookie: accessToken=<jwt-token>
+```
+
+**Request Body:** 없음
+
+### Success Response (200 OK)
+
+```json
+{
+  "userId": 1,
+  "email": "user@example.com",
+  "name": "홍길동",
+  "emailVerified": true
+}
+```
+
+**Response Fields:**
+- `userId` (Long): 사용자 ID
+- `email` (String): 사용자 이메일
+- `name` (String): 사용자 이름
+- `emailVerified` (Boolean): 이메일 인증 여부
+
+### Error Responses
+
+**401 Unauthorized:**
+```json
+{
+  "type": "about:blank",
+  "title": "인증 실패",
+  "status": 401,
+  "detail": "유효하지 않거나 만료된 토큰입니다.",
+  "instance": "/api/auth/me"
+}
+```
+
+### 구현 요구사항
+
+1. **토큰 검증:**
+   - HttpOnly Cookie에서 `accessToken` 추출
+   - JWT 토큰 유효성 검증 (서명, 만료 시간)
+   - 토큰에서 userId 추출
+
+2. **사용자 정보 조회:**
+   - userId로 DB에서 사용자 정보 조회
+   - 사용자가 존재하지 않으면 401 반환
+
+3. **보안:**
+   - Spring Security 인증 필터에서 처리
+   - CORS 설정 확인
+
+### 사용 시나리오
+
+1. **페이지 로드 시:**
+   - 사용자가 보호된 페이지(`/app/*`) 접근 시
+   - SvelteKit Layout에서 자동 호출
+   - 인증 실패 시 로그인 페이지로 리다이렉트
+
+2. **세션 검증:**
+   - 장시간 사용 후 세션 유효성 확인
+   - 토큰 갱신 후 사용자 정보 재확인
+
+---
+
+## 2. 로그아웃 API
+
+### 기본 정보
+
+**Endpoint:** `POST /api/auth/logout`
+
+**인증:** Required (Access Token via HttpOnly Cookie)
+
+**설명:** 사용자를 로그아웃하고 Refresh Token을 무효화합니다. HttpOnly Cookie를 삭제하여 클라이언트 측 토큰을 제거합니다.
+
+### Request
+
+**Headers:**
+```
+Cookie: accessToken=<jwt-token>; refreshToken=<jwt-token>
+Content-Type: application/json
+```
+
+**Request Body:**
+```json
+{
+  "deviceId": "device-uuid-or-identifier"
+}
+```
+
+**Body Fields:**
+- `deviceId` (String, Required): 로그아웃할 디바이스 식별자
+
+### Success Response (200 OK)
+
+```json
+{
+  "message": "로그아웃되었습니다."
+}
+```
+
+**추가 동작:**
+- `Set-Cookie` 헤더를 통해 `accessToken`과 `refreshToken` 삭제 (MaxAge=0)
+
+```
+Set-Cookie: accessToken=; Path=/; HttpOnly; Max-Age=0
+Set-Cookie: refreshToken=; Path=/; HttpOnly; Max-Age=0
+```
+
+### Error Responses
+
+**401 Unauthorized:**
+```json
+{
+  "type": "about:blank",
+  "title": "인증 실패",
+  "status": 401,
+  "detail": "유효하지 않거나 만료된 토큰입니다.",
+  "instance": "/api/auth/logout"
+}
+```
+
+**400 Bad Request:**
+```json
+{
+  "type": "about:blank",
+  "title": "잘못된 요청",
+  "status": 400,
+  "detail": "디바이스 ID는 필수입니다.",
+  "instance": "/api/auth/logout"
+}
+```
+
+### 구현 요구사항
+
+1. **토큰 검증:**
+   - HttpOnly Cookie에서 `accessToken` 추출
+   - JWT 토큰 유효성 검증
+   - 토큰에서 userId 추출
+
+2. **Refresh Token 삭제:**
+   - Request Body에서 `deviceId` 추출
+   - DB에서 `userId`와 `deviceId`에 해당하는 Refresh Token 삭제
+   - 해당 디바이스의 세션 완전히 무효화
+
+3. **Cookie 삭제:**
+   - `accessToken` Cookie 삭제 (MaxAge=0)
+   - `refreshToken` Cookie 삭제 (MaxAge=0)
+   - Path, Domain, HttpOnly 속성 동일하게 설정
+
+4. **보안:**
+   - Spring Security 인증 필터에서 처리
+   - CSRF 토큰 검증 (필요시)
+
+### 사용 시나리오
+
+1. **명시적 로그아웃:**
+   - 사용자가 헤더 메뉴에서 "로그아웃" 클릭
+   - 프론트엔드에서 localStorage의 deviceId 전송
+   - 로그아웃 성공 후 로그인 페이지로 리다이렉트
+
+2. **보안 로그아웃:**
+   - 비밀번호 변경 후 모든 디바이스 로그아웃
+   - 의심스러운 활동 감지 시 강제 로그아웃
+
+---
+
+## 구현 우선순위
+
+### 1. 높음: `GET /api/auth/me`
+- **이유:** 프론트엔드 인증 가드에 필수
+- **영향:** 이 API 없이는 보호된 페이지 접근 불가
+- **구현 시점:** JWT 인증 필터 구현 직후
+
+### 2. 중간: `POST /api/auth/logout`
+- **이유:** 사용자 경험 개선에 필요
+- **대안:** 현재는 프론트엔드에서 로컬 상태만 초기화 (토큰은 만료 대기)
+- **구현 시점:** `/api/auth/me` 완료 후
+
+---
+
+## 기술적 고려사항
+
+### 1. 성능 최적화
+
+**`GET /api/auth/me` 호출 빈도:**
+- 매 페이지 로드마다 호출될 수 있음
+- DB 조회 최소화 고려 (캐싱, Redis 세션 등)
+- JWT 토큰에 필요한 정보 포함하여 DB 조회 생략 가능
+
+**권장 구현:**
+```java
+// 토큰에서 추출한 정보로 응답 구성 (DB 조회 없이)
+Claims claims = jwtTokenProvider.parseClaims(accessToken);
+return UserInfoResponse.builder()
+    .userId(claims.get("sub", Long.class))
+    .email(claims.get("email", String.class))
+    .emailVerified(claims.get("emailVerified", Boolean.class))
+    .name(claims.get("name", String.class)) // 토큰에 name 추가 필요
+    .build();
+```
+
+### 2. 다중 디바이스 로그아웃
+
+**현재 구현:** 디바이스별 Refresh Token 관리
+- 로그아웃 시 해당 deviceId의 토큰만 삭제
+- 다른 디바이스 세션은 유지
+
+**추가 고려사항:**
+- "모든 디바이스에서 로그아웃" 기능 필요 여부
+- 특정 디바이스 세션 관리 UI 필요 여부
+
+### 3. JWT Claims 구조 확장
+
+**현재 Access Token Claims:**
+```
+{
+  "sub": userId,
+  "email": "user@example.com",
+  "type": "access",
+  "iat": 1234567890,
+  "exp": 1234571490
+}
+```
+
+**필요한 추가 Claims:**
+```
+{
+  "sub": userId,
+  "email": "user@example.com",
+  "name": "홍길동",              // 추가 필요
+  "emailVerified": true,          // 추가 필요
+  "type": "access",
+  "iat": 1234567890,
+  "exp": 1234571490
+}
+```
+
+---
+
+## 의존성
+
+### 선행 작업
+- ✅ JWT 토큰 발급 로직 (완료)
+- ⏳ JWT 인증 필터/인터셉터 구현
+- ⏳ Spring Security 설정
+
+### 관련 문서
+- [백엔드 인증 API 문서](../../backend/src/main/java/app/aipacemaker/backend/auth/docs/api.md)
+- [프론트엔드 인증 시스템 명세](../../specifications/v1.0.0/DS/01-authentication-system.md)
+
+---
+
+## 테스트 시나리오
+
+### `GET /api/auth/me` 테스트
+
+1. **정상 케이스:**
+   - 유효한 accessToken으로 요청
+   - 200 OK 및 사용자 정보 반환
+
+2. **인증 실패:**
+   - accessToken 없이 요청 → 401
+   - 만료된 accessToken → 401
+   - 잘못된 서명의 accessToken → 401
+   - 존재하지 않는 userId → 401
+
+### `POST /api/auth/logout` 테스트
+
+1. **정상 케이스:**
+   - 유효한 accessToken + deviceId로 요청
+   - 200 OK 및 Cookie 삭제 확인
+   - DB에서 Refresh Token 삭제 확인
+
+2. **인증 실패:**
+   - accessToken 없이 요청 → 401
+   - 만료된 accessToken → 401
+
+3. **잘못된 요청:**
+   - deviceId 누락 → 400
+
+4. **재로그인 불가:**
+   - 로그아웃 후 refreshToken으로 갱신 시도 → 401
+
+---
+
+## 문의사항
+
+질문이나 추가 요구사항이 있으면 프론트엔드 팀에 문의해주세요.
+
+**연락처:** [프론트엔드 팀 연락처]

--- a/docs/requirements/frontend-temporary-workaround.md
+++ b/docs/requirements/frontend-temporary-workaround.md
@@ -1,0 +1,238 @@
+# 프론트엔드 임시 우회 방안
+
+**작성일:** 2025-01-16
+**상태:** 임시 조치
+**관련 문서:** [인증 API 추가 요구사항](./auth-api-requirements.md)
+
+---
+
+## 개요
+
+백엔드 `/api/auth/me` 및 `/api/auth/logout` API가 구현되기 전까지 프론트엔드에서 사용할 임시 우회 방안입니다.
+
+---
+
+## 1. 사용자 정보 조회 (`/api/auth/me`) 우회
+
+### 현재 상황
+- SvelteKit Layout (`/routes/(app)/+layout.ts`)에서 `/api/auth/me` 호출
+- 해당 API가 백엔드에 구현되지 않음
+- 보호된 페이지 접근 시 에러 발생
+
+### 임시 해결 방법
+
+**옵션 1: 로그인 후 사용자 정보를 로컬 상태에 저장**
+
+로그인 성공 시 받은 사용자 정보를 authStore에 저장하고, Layout에서 authStore를 확인:
+
+```typescript
+// routes/(app)/+layout.ts
+import { authStore } from '$lib/stores/auth.svelte';
+import { redirect } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ url }) => {
+	// authStore에서 사용자 정보 확인
+	if (!authStore.isAuthenticated) {
+		// 인증되지 않은 경우 로그인 페이지로 리다이렉트
+		throw redirect(303, `/login?redirectTo=${encodeURIComponent(url.pathname)}`);
+	}
+
+	return {
+		user: authStore.user
+	};
+};
+```
+
+**장점:**
+- 빠른 페이지 로드 (API 호출 없음)
+- 간단한 구현
+
+**단점:**
+- 페이지 새로고침 시 인증 상태 유실 (authStore는 메모리 기반)
+- 다른 탭/창에서 로그아웃 시 동기화 안됨
+- 토큰 만료 감지 불가
+
+**옵션 2: 토큰 존재 여부만 확인 (권장)**
+
+Cookie에 accessToken이 있는지만 확인하고, 실제 검증은 API 요청 시 자동으로 처리:
+
+```typescript
+// routes/(app)/+layout.ts
+import { redirect } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ cookies, url }) => {
+	const accessToken = cookies.get('accessToken');
+
+	if (!accessToken) {
+		// accessToken이 없으면 로그인 페이지로
+		throw redirect(303, `/login?redirectTo=${encodeURIComponent(url.pathname)}`);
+	}
+
+	// 토큰이 있으면 일단 통과 (실제 검증은 API 호출 시 자동 처리)
+	// 임시로 최소한의 사용자 정보 반환
+	return {
+		user: {
+			email: 'user@example.com', // 임시
+			name: '사용자' // 임시
+		}
+	};
+};
+```
+
+**장점:**
+- 서버 사이드에서 Cookie 확인 가능
+- 토큰이 없으면 바로 리다이렉트
+- API 구현 전까지 동작 가능
+
+**단점:**
+- 토큰 유효성 검증 안됨
+- 실제 사용자 정보가 아닌 임시 데이터
+
+---
+
+## 2. 로그아웃 (`/api/auth/logout`) 우회
+
+### 현재 상황
+- authStore.logout()에서 `/api/auth/logout` 호출
+- 해당 API가 백엔드에 구현되지 않음
+- HttpOnly Cookie를 클라이언트에서 직접 삭제 불가
+
+### 임시 해결 방법
+
+**로컬 상태만 초기화:**
+
+```typescript
+// lib/stores/auth.svelte.ts
+async logout() {
+	try {
+		// HttpOnly Cookie는 클라이언트에서 삭제 불가
+		// 로컬 상태만 초기화
+		this.setUser(null);
+
+		// 로그인 페이지로 리다이렉트
+		// 토큰은 만료되거나 다음 로그인 시 덮어씌워짐
+	} catch (error) {
+		console.error('로그아웃 오류:', error);
+		this.setUser(null);
+	}
+}
+```
+
+**장점:**
+- API 구현 없이 동작
+- 사용자 경험상 로그아웃 된 것처럼 보임
+
+**단점:**
+- Cookie의 토큰은 여전히 유효 (만료까지 1시간)
+- 보안상 완전한 로그아웃이 아님
+- DB에 Refresh Token 남아있음 (30일)
+
+**권장 방안:**
+- API 구현 전까지는 위 방식 사용
+- API 구현 후 즉시 통합
+- 중요: 보안이 중요한 작업 전에는 반드시 API 구현 필요
+
+---
+
+## 3. 구현 코드
+
+### `routes/(app)/+layout.ts` (옵션 2 - 권장)
+
+```typescript
+import { redirect } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ cookies, url }) => {
+	// Cookie에서 accessToken 확인
+	const accessToken = cookies.get('accessToken');
+
+	if (!accessToken) {
+		// 토큰이 없으면 로그인 페이지로 리다이렉트
+		throw redirect(303, `/login?redirectTo=${encodeURIComponent(url.pathname)}`);
+	}
+
+	// TODO: /api/auth/me 구현 후 실제 사용자 정보 조회
+	// 현재는 임시 데이터 반환
+	return {
+		user: {
+			name: '사용자',
+			email: 'user@example.com'
+		}
+	};
+};
+```
+
+### `lib/stores/auth.svelte.ts` - logout 메서드
+
+```typescript
+// 로그아웃
+async logout() {
+	try {
+		// TODO: /api/auth/logout 구현 후 API 호출
+		// await apiPost('/api/auth/logout', { deviceId: getOrCreateDeviceId() });
+
+		// 현재는 로컬 상태만 초기화
+		this.setUser(null);
+	} catch (error) {
+		console.error('로그아웃 오류:', error);
+		this.setUser(null);
+	}
+}
+```
+
+---
+
+## 4. API 구현 후 통합 체크리스트
+
+### `/api/auth/me` 구현 완료 시
+
+- [ ] `routes/(app)/+layout.ts` 수정
+  - [ ] 실제 `/api/auth/me` API 호출
+  - [ ] 응답에서 실제 사용자 정보 사용
+  - [ ] 에러 처리 (401 시 로그인 페이지 리다이렉트)
+
+- [ ] `lib/stores/auth.svelte.ts` 수정
+  - [ ] `fetchUser()` 메서드 활성화
+  - [ ] 실제 API 호출로 변경
+
+### `/api/auth/logout` 구현 완료 시
+
+- [ ] `lib/stores/auth.svelte.ts` 수정
+  - [ ] `logout()` 메서드에 API 호출 추가
+  - [ ] deviceId 전송
+  - [ ] 에러 처리
+
+- [ ] 테스트
+  - [ ] 로그아웃 후 토큰 삭제 확인
+  - [ ] 로그아웃 후 보호된 페이지 접근 불가 확인
+  - [ ] 로그아웃 후 토큰 갱신 불가 확인
+
+---
+
+## 5. 주의사항
+
+### 보안
+- 임시 방안은 완전한 인증 검증이 아님
+- 프로덕션 배포 전 반드시 API 구현 필요
+- 민감한 데이터 처리 시 주의
+
+### 사용자 경험
+- 페이지 새로고침 시 인증 상태 유실 가능
+- 다중 탭/창에서 동기화 안됨
+- 토큰 만료 시 갑작스러운 로그아웃 경험
+
+### 개발
+- TODO 주석으로 표시하여 추후 수정 위치 명확화
+- API 구현 후 즉시 통합 테스트 진행
+- 문서 업데이트
+
+---
+
+## 관련 이슈
+
+- [ ] 백엔드: JWT 인증 필터 구현
+- [ ] 백엔드: `/api/auth/me` 구현
+- [ ] 백엔드: `/api/auth/logout` 구현
+- [ ] 프론트엔드: API 구현 후 통합

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,149 @@
+/**
+ * API 클라이언트 - 자동 토큰 갱신 인터셉터 포함
+ *
+ * 401 Unauthorized 에러 발생 시 자동으로 토큰을 갱신하고,
+ * 원래 요청을 재시도합니다.
+ */
+
+import { goto } from '$app/navigation';
+
+// 토큰 갱신 중복 방지를 위한 Promise 저장소
+let refreshTokenPromise: Promise<boolean> | null = null;
+
+/**
+ * Refresh Token을 사용하여 Access Token 갱신
+ *
+ * @returns {Promise<boolean>} 갱신 성공 여부
+ */
+async function refreshAccessToken(): Promise<boolean> {
+	try {
+		const response = await fetch('/api/auth/refresh', {
+			method: 'POST',
+			credentials: 'include' // HttpOnly Cookie 전송
+		});
+
+		if (!response.ok) {
+			return false;
+		}
+
+		// Access Token이 HttpOnly Cookie로 설정됨
+		return true;
+	} catch (error) {
+		console.error('토큰 갱신 실패:', error);
+		return false;
+	}
+}
+
+/**
+ * API 요청 헬퍼 함수 (자동 토큰 갱신 포함)
+ *
+ * @param url - 요청 URL
+ * @param options - fetch options
+ * @param retryCount - 재시도 횟수 (내부 사용)
+ * @returns {Promise<Response>}
+ */
+export async function apiClient(
+	url: string,
+	options: RequestInit = {},
+	retryCount = 0
+): Promise<Response> {
+	// credentials: 'include'를 기본값으로 설정 (Cookie 전송)
+	const finalOptions: RequestInit = {
+		...options,
+		credentials: 'include'
+	};
+
+	try {
+		const response = await fetch(url, finalOptions);
+
+		// 401 Unauthorized 에러 처리
+		if (response.status === 401 && retryCount === 0) {
+			// 토큰 갱신이 이미 진행 중이면 해당 Promise를 재사용
+			if (!refreshTokenPromise) {
+				refreshTokenPromise = refreshAccessToken().finally(() => {
+					refreshTokenPromise = null;
+				});
+			}
+
+			const refreshSuccess = await refreshTokenPromise;
+
+			if (refreshSuccess) {
+				// 토큰 갱신 성공 시 원래 요청 재시도
+				return apiClient(url, options, retryCount + 1);
+			} else {
+				// 토큰 갱신 실패 시 로그인 페이지로 리다이렉트
+				goto(`/login?redirectTo=${encodeURIComponent(window.location.pathname)}`);
+				throw new Error('인증이 만료되었습니다. 다시 로그인해주세요.');
+			}
+		}
+
+		return response;
+	} catch (error) {
+		// 네트워크 오류 등
+		throw error;
+	}
+}
+
+/**
+ * API GET 요청
+ */
+export async function apiGet<T>(url: string): Promise<T> {
+	const response = await apiClient(url, { method: 'GET' });
+
+	if (!response.ok) {
+		throw new Error(`API 요청 실패: ${response.status}`);
+	}
+
+	return response.json();
+}
+
+/**
+ * API POST 요청
+ */
+export async function apiPost<T>(url: string, data?: unknown): Promise<T> {
+	const response = await apiClient(url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: data ? JSON.stringify(data) : undefined
+	});
+
+	if (!response.ok) {
+		throw new Error(`API 요청 실패: ${response.status}`);
+	}
+
+	return response.json();
+}
+
+/**
+ * API PUT 요청
+ */
+export async function apiPut<T>(url: string, data?: unknown): Promise<T> {
+	const response = await apiClient(url, {
+		method: 'PUT',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: data ? JSON.stringify(data) : undefined
+	});
+
+	if (!response.ok) {
+		throw new Error(`API 요청 실패: ${response.status}`);
+	}
+
+	return response.json();
+}
+
+/**
+ * API DELETE 요청
+ */
+export async function apiDelete<T>(url: string): Promise<T> {
+	const response = await apiClient(url, { method: 'DELETE' });
+
+	if (!response.ok) {
+		throw new Error(`API 요청 실패: ${response.status}`);
+	}
+
+	return response.json();
+}

--- a/frontend/src/lib/components/auth/AuthCard.svelte
+++ b/frontend/src/lib/components/auth/AuthCard.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	/**
+	 * AuthCard 컴포넌트
+	 * 인증 화면의 중앙 카드 래퍼
+	 */
+	interface Props {
+		title: string;
+		description: string;
+		children?: import('svelte').Snippet;
+	}
+
+	let { title, description, children }: Props = $props();
+</script>
+
+<div class="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4">
+	<div class="w-full max-w-md">
+		<div class="card">
+			<h1 class="text-2xl font-bold text-[#171717] mb-2">{title}</h1>
+			<p class="text-sm text-[#737373] mb-6">{description}</p>
+
+			{#if children}
+				{@render children()}
+			{/if}
+		</div>
+	</div>
+</div>

--- a/frontend/src/lib/components/auth/ErrorAlert.svelte
+++ b/frontend/src/lib/components/auth/ErrorAlert.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	/**
+	 * ErrorAlert 컴포넌트
+	 * 전역 에러/성공 메시지 표시
+	 */
+	interface Props {
+		message: string;
+		type?: 'error' | 'success' | 'info';
+	}
+
+	let { message, type = 'error' }: Props = $props();
+
+	const styles = $derived({
+		error: {
+			bg: 'bg-red-50',
+			border: 'border-red-200',
+			text: 'text-red-600'
+		},
+		success: {
+			bg: 'bg-green-50',
+			border: 'border-green-200',
+			text: 'text-green-600'
+		},
+		info: {
+			bg: 'bg-blue-50',
+			border: 'border-blue-200',
+			text: 'text-blue-600'
+		}
+	}[type]);
+</script>
+
+{#if message}
+	<div
+		class="mb-4 p-3 rounded-lg text-sm border {styles.bg} {styles.border} {styles.text}"
+		role="alert"
+	>
+		{message}
+	</div>
+{/if}

--- a/frontend/src/lib/components/auth/FormInput.svelte
+++ b/frontend/src/lib/components/auth/FormInput.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	/**
+	 * FormInput 컴포넌트
+	 * 레이블, 입력 필드, 에러 메시지를 통합한 폼 입력 컴포넌트
+	 */
+	interface Props {
+		id: string;
+		label: string;
+		type?: 'text' | 'email' | 'password';
+		placeholder?: string;
+		value: string;
+		error?: string;
+		required?: boolean;
+		disabled?: boolean;
+		autocomplete?: string;
+		minlength?: number;
+		onInput?: (value: string) => void;
+	}
+
+	let {
+		id,
+		label,
+		type = 'text',
+		placeholder = '',
+		value = $bindable(),
+		error = '',
+		required = false,
+		disabled = false,
+		autocomplete,
+		minlength,
+		onInput
+	}: Props = $props();
+
+	function handleInput(event: Event) {
+		const target = event.target as HTMLInputElement;
+		value = target.value;
+		if (onInput) {
+			onInput(target.value);
+		}
+	}
+</script>
+
+<div>
+	<label for={id} class="block text-sm font-medium text-[#404040] mb-1">
+		{label}
+		{#if required}
+			<span class="text-red-500" aria-label="필수">*</span>
+		{/if}
+	</label>
+	<input
+		{id}
+		{type}
+		{placeholder}
+		{value}
+		{disabled}
+		{required}
+		autocomplete={autocomplete}
+		minlength={minlength}
+		class="input"
+		class:border-red-500={error}
+		aria-invalid={!!error}
+		aria-describedby={error ? `${id}-error` : undefined}
+		aria-required={required}
+		oninput={handleInput}
+	/>
+	{#if error}
+		<p id="{id}-error" class="mt-1 text-sm text-red-600" role="alert">
+			{error}
+		</p>
+	{/if}
+</div>

--- a/frontend/src/lib/components/auth/LoadingButton.svelte
+++ b/frontend/src/lib/components/auth/LoadingButton.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	/**
+	 * LoadingButton 컴포넌트
+	 * 로딩 상태를 시각적으로 표시하는 버튼
+	 */
+	interface Props {
+		type?: 'submit' | 'button' | 'reset';
+		loading?: boolean;
+		disabled?: boolean;
+		variant?: 'primary' | 'secondary';
+		loadingText?: string;
+		children?: import('svelte').Snippet;
+	}
+
+	let {
+		type = 'submit',
+		loading = false,
+		disabled = false,
+		variant = 'primary',
+		loadingText = '처리 중...',
+		children
+	}: Props = $props();
+
+	const isDisabled = $derived(loading || disabled);
+</script>
+
+<button
+	{type}
+	disabled={isDisabled}
+	class="w-full px-4 py-3 rounded-lg transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+	class:bg-[#FF6B4A]={variant === 'primary'}
+	class:hover:bg-[#FF5A39]={variant === 'primary' && !isDisabled}
+	class:text-white={variant === 'primary'}
+	class:bg-gray-200={variant === 'secondary'}
+	class:hover:bg-gray-300={variant === 'secondary' && !isDisabled}
+	class:text-gray-700={variant === 'secondary'}
+>
+	{#if loading}
+		<span class="flex items-center justify-center gap-2">
+			<svg
+				class="animate-spin h-5 w-5"
+				xmlns="http://www.w3.org/2000/svg"
+				fill="none"
+				viewBox="0 0 24 24"
+			>
+				<circle
+					class="opacity-25"
+					cx="12"
+					cy="12"
+					r="10"
+					stroke="currentColor"
+					stroke-width="4"
+				></circle>
+				<path
+					class="opacity-75"
+					fill="currentColor"
+					d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+				></path>
+			</svg>
+			{loadingText}
+		</span>
+	{:else if children}
+		{@render children()}
+	{/if}
+</button>

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -1,10 +1,24 @@
 // 사용자 인증 상태를 관리하는 Svelte 5 Runes 기반 스토어
 import type { User } from '$lib/types/navigation';
+import { apiPost } from '$lib/api/client';
+import { getOrCreateDeviceId } from '$lib/utils/device';
 
 interface AuthState {
 	user: User | null;
 	isLoading: boolean;
 	isAuthenticated: boolean;
+}
+
+interface LoginResponse {
+	userId: number;
+	email: string;
+	emailVerified: boolean;
+}
+
+interface RegisterResponse {
+	userId: number;
+	email: string;
+	message: string;
 }
 
 // 초기 상태
@@ -47,43 +61,60 @@ function createAuthStore() {
 			try {
 				state.isLoading = true;
 
-				const response = await fetch('/api/auth/login', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json'
-					},
-					body: JSON.stringify({ email, password }),
-					credentials: 'include' // HttpOnly Cookie 포함
+				const deviceId = getOrCreateDeviceId();
+				const data = await apiPost<LoginResponse>('/api/auth/login', {
+					email,
+					password,
+					deviceId
 				});
 
-				if (!response.ok) {
-					throw new Error('로그인에 실패했습니다.');
-				}
-
-				const data = await response.json();
-
-				// 사용자 정보 저장 (백엔드 응답 구조에 따라 조정 필요)
+				// 토큰은 HttpOnly Cookie로 자동 저장됨
+				// 사용자 정보만 스토어에 저장
 				this.setUser({
-					name: data.name || data.username || email.split('@')[0],
-					email: data.email || email,
-					avatar: data.avatar
+					name: email.split('@')[0], // 백엔드에서 name을 제공하지 않으므로 이메일에서 추출
+					email: data.email,
+					avatar: undefined
 				});
 
-				return { success: true };
+				return { success: true, emailVerified: data.emailVerified };
 			} catch (error) {
 				state.isLoading = false;
 				console.error('로그인 오류:', error);
-				return { success: false, error: '로그인에 실패했습니다.' };
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : '로그인에 실패했습니다.'
+				};
+			}
+		},
+
+		// 회원가입
+		async register(name: string, email: string, password: string) {
+			try {
+				state.isLoading = true;
+
+				const data = await apiPost<RegisterResponse>('/api/users', {
+					name,
+					email,
+					password
+				});
+
+				state.isLoading = false;
+				return { success: true, message: data.message };
+			} catch (error) {
+				state.isLoading = false;
+				console.error('회원가입 오류:', error);
+				return {
+					success: false,
+					error: error instanceof Error ? error.message : '회원가입에 실패했습니다.'
+				};
 			}
 		},
 
 		// 로그아웃
 		async logout() {
 			try {
-				await fetch('/api/auth/logout', {
-					method: 'POST',
-					credentials: 'include'
-				});
+				// 로그아웃 API 호출 (Cookie 삭제)
+				await apiPost('/api/auth/logout', {});
 			} catch (error) {
 				console.error('로그아웃 오류:', error);
 			} finally {
@@ -97,6 +128,7 @@ function createAuthStore() {
 			try {
 				state.isLoading = true;
 
+				// apiClient를 사용하면 401 시 자동으로 토큰 갱신 시도
 				const response = await fetch('/api/auth/me', {
 					credentials: 'include'
 				});
@@ -104,7 +136,7 @@ function createAuthStore() {
 				if (response.ok) {
 					const data = await response.json();
 					this.setUser({
-						name: data.name || data.username || data.email?.split('@')[0] || '사용자',
+						name: data.name || data.email?.split('@')[0] || '사용자',
 						email: data.email,
 						avatar: data.avatar
 					});

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -113,12 +113,14 @@ function createAuthStore() {
 		// 로그아웃
 		async logout() {
 			try {
-				// 로그아웃 API 호출 (Cookie 삭제)
-				await apiPost('/api/auth/logout', {});
+				// TODO: 백엔드 /api/auth/logout API 구현 후 활성화
+				// await apiPost('/api/auth/logout', { deviceId: getOrCreateDeviceId() });
+
+				// 현재는 로컬 상태만 초기화 (HttpOnly Cookie는 클라이언트에서 삭제 불가)
+				// 토큰은 만료되거나 다음 로그인 시 덮어씌워짐
+				this.setUser(null);
 			} catch (error) {
 				console.error('로그아웃 오류:', error);
-			} finally {
-				// 로컬 상태 초기화
 				this.setUser(null);
 			}
 		},

--- a/frontend/src/lib/utils/device.ts
+++ b/frontend/src/lib/utils/device.ts
@@ -1,0 +1,41 @@
+/**
+ * 브라우저 디바이스 식별자 관리 유틸리티
+ *
+ * deviceId는 다중 디바이스 로그인을 지원하기 위해 사용됩니다.
+ * localStorage에 저장하여 동일 브라우저에서는 같은 deviceId를 사용합니다.
+ */
+
+const DEVICE_ID_KEY = 'deviceId';
+
+/**
+ * deviceId를 가져오거나 생성합니다.
+ * localStorage에 저장된 deviceId가 있으면 반환하고, 없으면 새로 생성합니다.
+ *
+ * @returns {string} deviceId
+ */
+export function getOrCreateDeviceId(): string {
+	if (typeof window === 'undefined') {
+		// SSR 환경에서는 임시 ID 반환 (실제로는 클라이언트에서만 사용됨)
+		return 'ssr-temp-device-id';
+	}
+
+	let deviceId = localStorage.getItem(DEVICE_ID_KEY);
+
+	if (!deviceId) {
+		// crypto.randomUUID()는 modern browsers에서 지원
+		deviceId = crypto.randomUUID();
+		localStorage.setItem(DEVICE_ID_KEY, deviceId);
+	}
+
+	return deviceId;
+}
+
+/**
+ * 저장된 deviceId를 삭제합니다.
+ * (주로 테스트 또는 디버깅 목적으로 사용)
+ */
+export function clearDeviceId(): void {
+	if (typeof window !== 'undefined') {
+		localStorage.removeItem(DEVICE_ID_KEY);
+	}
+}

--- a/frontend/src/routes/(app)/+layout.ts
+++ b/frontend/src/routes/(app)/+layout.ts
@@ -1,35 +1,25 @@
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 
-export const load: LayoutLoad = async ({ fetch, url }) => {
-	try {
-		// 세션 확인: /api/auth/me 엔드포인트 호출
-		const response = await fetch('/api/auth/me', {
-			credentials: 'include'
-		});
+export const load: LayoutLoad = async ({ cookies, url }) => {
+	// TODO: 백엔드 /api/auth/me API 구현 후 실제 API 호출로 변경
+	// 현재는 Cookie에 accessToken이 있는지만 확인하는 임시 방안 사용
 
-		if (!response.ok) {
-			// 인증 실패 시 로그인 페이지로 리디렉션
-			// 현재 URL을 쿼리 파라미터로 저장하여 로그인 후 복귀 가능
-			throw redirect(303, `/login?redirectTo=${encodeURIComponent(url.pathname)}`);
-		}
+	// Cookie에서 accessToken 확인
+	const accessToken = cookies.get('accessToken');
 
-		const user = await response.json();
-
-		return {
-			user: {
-				name: user.name || user.username || user.email?.split('@')[0] || '사용자',
-				email: user.email,
-				avatar: user.avatar
-			}
-		};
-	} catch (error) {
-		// redirect는 throw되므로 그대로 전파
-		if (error instanceof Response) {
-			throw error;
-		}
-
-		// 기타 에러 시 로그인 페이지로 리디렉션
+	if (!accessToken) {
+		// 토큰이 없으면 로그인 페이지로 리다이렉트
 		throw redirect(303, `/login?redirectTo=${encodeURIComponent(url.pathname)}`);
 	}
+
+	// TODO: /api/auth/me 구현 후 실제 사용자 정보 조회
+	// 현재는 임시 데이터 반환
+	// 실제 사용자 정보는 API 요청 시 자동으로 토큰 검증됨
+	return {
+		user: {
+			name: '사용자',
+			email: 'user@example.com'
+		}
+	};
 };

--- a/frontend/src/routes/(public)/signup/+page.svelte
+++ b/frontend/src/routes/(public)/signup/+page.svelte
@@ -1,79 +1,162 @@
 <script lang="ts">
-	// TODO: 실제 회원가입 로직 구현
-	function handleSignup(event: Event) {
+	import { goto } from '$app/navigation';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import AuthCard from '$lib/components/auth/AuthCard.svelte';
+	import FormInput from '$lib/components/auth/FormInput.svelte';
+	import LoadingButton from '$lib/components/auth/LoadingButton.svelte';
+	import ErrorAlert from '$lib/components/auth/ErrorAlert.svelte';
+
+	let name = $state('');
+	let email = $state('');
+	let password = $state('');
+	let passwordConfirm = $state('');
+
+	let errorMessage = $state('');
+	let fieldErrors = $state({
+		name: '',
+		email: '',
+		password: '',
+		passwordConfirm: ''
+	});
+	let isLoading = $state(false);
+
+	// 클라이언트 사이드 유효성 검사
+	function validateForm(): boolean {
+		fieldErrors = {
+			name: '',
+			email: '',
+			password: '',
+			passwordConfirm: ''
+		};
+
+		let isValid = true;
+
+		if (!name.trim()) {
+			fieldErrors.name = '이름을 입력해주세요';
+			isValid = false;
+		}
+
+		if (!email.trim()) {
+			fieldErrors.email = '이메일을 입력해주세요';
+			isValid = false;
+		} else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+			fieldErrors.email = '올바른 이메일 주소를 입력해주세요';
+			isValid = false;
+		}
+
+		if (!password) {
+			fieldErrors.password = '비밀번호를 입력해주세요';
+			isValid = false;
+		} else if (password.length < 8) {
+			fieldErrors.password = '비밀번호는 8자 이상이어야 합니다';
+			isValid = false;
+		}
+
+		if (!passwordConfirm) {
+			fieldErrors.passwordConfirm = '비밀번호 확인을 입력해주세요';
+			isValid = false;
+		} else if (password !== passwordConfirm) {
+			fieldErrors.passwordConfirm = '비밀번호가 일치하지 않습니다';
+			isValid = false;
+		}
+
+		return isValid;
+	}
+
+	async function handleSignup(event: Event) {
 		event.preventDefault();
-		// 임시: 로그인 페이지로 리다이렉트
-		window.location.href = '/login';
+		errorMessage = '';
+
+		if (!validateForm()) {
+			return;
+		}
+
+		isLoading = true;
+
+		try {
+			const result = await authStore.register(name, email, password);
+
+			if (result.success) {
+				// 회원가입 성공 - 로그인 페이지로 이동하며 성공 메시지 전달
+				await goto(`/login?message=${encodeURIComponent(result.message || '회원가입이 완료되었습니다.')}`);
+			} else {
+				errorMessage = result.error || '회원가입에 실패했습니다.';
+			}
+		} catch (error) {
+			errorMessage = '회원가입 중 오류가 발생했습니다.';
+			console.error('회원가입 오류:', error);
+		} finally {
+			isLoading = false;
+		}
 	}
 </script>
 
-<div class="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4">
-	<div class="w-full max-w-md">
-		<div class="card">
-			<h1 class="text-2xl font-bold text-[#171717] mb-2">회원가입</h1>
-			<p class="text-sm text-[#737373] mb-6">성장의 여정을 시작하세요</p>
+<AuthCard title="회원가입" description="성장의 여정을 시작하세요">
+	{#snippet children()}
+		<ErrorAlert message={errorMessage} type="error" />
 
-			<form onsubmit={handleSignup} class="space-y-4">
-				<div>
-					<label for="name" class="block text-sm font-medium text-[#404040] mb-1"> 이름 </label>
-					<input type="text" id="name" class="input" placeholder="홍길동" required />
-				</div>
+		<form onsubmit={handleSignup} class="space-y-4">
+			<FormInput
+				id="name"
+				label="이름"
+				type="text"
+				placeholder="홍길동"
+				bind:value={name}
+				error={fieldErrors.name}
+				required
+				disabled={isLoading}
+			/>
 
-				<div>
-					<label for="email" class="block text-sm font-medium text-[#404040] mb-1">
-						이메일
-					</label>
-					<input
-						type="email"
-						id="email"
-						class="input"
-						placeholder="example@email.com"
-						required
-					/>
-				</div>
+			<FormInput
+				id="email"
+				label="이메일"
+				type="email"
+				placeholder="example@email.com"
+				bind:value={email}
+				error={fieldErrors.email}
+				required
+				disabled={isLoading}
+				autocomplete="email"
+			/>
 
-				<div>
-					<label for="password" class="block text-sm font-medium text-[#404040] mb-1">
-						비밀번호
-					</label>
-					<input
-						type="password"
-						id="password"
-						class="input"
-						placeholder="8자 이상 입력"
-						minlength="8"
-						required
-					/>
-				</div>
+			<FormInput
+				id="password"
+				label="비밀번호"
+				type="password"
+				placeholder="8자 이상 입력"
+				bind:value={password}
+				error={fieldErrors.password}
+				required
+				disabled={isLoading}
+				minlength={8}
+				autocomplete="new-password"
+			/>
 
-				<div>
-					<label for="password-confirm" class="block text-sm font-medium text-[#404040] mb-1">
-						비밀번호 확인
-					</label>
-					<input
-						type="password"
-						id="password-confirm"
-						class="input"
-						placeholder="비밀번호 재입력"
-						minlength="8"
-						required
-					/>
-				</div>
+			<FormInput
+				id="password-confirm"
+				label="비밀번호 확인"
+				type="password"
+				placeholder="비밀번호 재입력"
+				bind:value={passwordConfirm}
+				error={fieldErrors.passwordConfirm}
+				required
+				disabled={isLoading}
+				minlength={8}
+				autocomplete="new-password"
+			/>
 
-				<button
-					type="submit"
-					class="w-full px-4 py-3 bg-[#FF6B4A] text-white rounded-lg hover:bg-[#FF5A39] transition-colors font-medium"
-				>
+			<LoadingButton loading={isLoading} loadingText="회원가입 중...">
+				{#snippet children()}
 					회원가입
-				</button>
-			</form>
+				{/snippet}
+			</LoadingButton>
+		</form>
 
-			<div class="mt-6 text-center">
-				<p class="text-sm text-[#737373]">
-					이미 계정이 있으신가요?
-					<a href="/login" class="text-[#FF6B4A] font-medium hover:underline">로그인</a>
-				</p>
-			</div>
+		<div class="mt-6 text-center">
+			<p class="text-sm text-[#737373]">
+				이미 계정이 있으신가요?
+				<a href="/login" class="text-[#FF6B4A] font-medium hover:underline">로그인</a>
+			</p>
 		</div>
-	</div>
-</div>
+	{/snippet}
+</AuthCard>

--- a/frontend/src/routes/(public)/signup/+page.svelte
+++ b/frontend/src/routes/(public)/signup/+page.svelte
@@ -50,6 +50,9 @@
 		} else if (password.length < 8) {
 			fieldErrors.password = '비밀번호는 8자 이상이어야 합니다';
 			isValid = false;
+		} else if (!/^(?=.*[A-Za-z])(?=.*\d).+$/.test(password)) {
+			fieldErrors.password = '비밀번호는 영문자와 숫자를 포함해야 합니다';
+			isValid = false;
 		}
 
 		if (!passwordConfirm) {
@@ -123,7 +126,7 @@
 				id="password"
 				label="비밀번호"
 				type="password"
-				placeholder="8자 이상 입력"
+				placeholder="8자 이상, 영문+숫자 포함"
 				bind:value={password}
 				error={fieldErrors.password}
 				required

--- a/frontend/src/routes/(public)/verify-email/+page.svelte
+++ b/frontend/src/routes/(public)/verify-email/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import AuthCard from '$lib/components/auth/AuthCard.svelte';
+	import ErrorAlert from '$lib/components/auth/ErrorAlert.svelte';
+	import LoadingButton from '$lib/components/auth/LoadingButton.svelte';
+	import { apiPost } from '$lib/api/client';
+
+	let email = $state('');
+	let token = $state('');
+	let isVerifying = $state(false);
+	let isVerified = $state(false);
+	let errorMessage = $state('');
+	let successMessage = $state('');
+
+	onMount(() => {
+		// URL 쿼리 파라미터에서 이메일과 토큰 읽기
+		email = $page.url.searchParams.get('email') || '';
+		token = $page.url.searchParams.get('token') || '';
+
+		// 토큰이 있으면 자동으로 인증 시도
+		if (token) {
+			verifyEmail();
+		}
+	});
+
+	async function verifyEmail() {
+		if (!token) {
+			errorMessage = '유효하지 않은 인증 링크입니다.';
+			return;
+		}
+
+		isVerifying = true;
+		errorMessage = '';
+
+		try {
+			const response = await apiPost<{
+				userId: number;
+				email: string;
+				verified: boolean;
+				message: string;
+			}>('/api/users/verification', { token });
+
+			isVerified = true;
+			successMessage = response.message || '이메일 인증이 완료되었습니다.';
+
+			// 3초 후 로그인 페이지로 이동
+			setTimeout(() => {
+				goto('/login?message=' + encodeURIComponent('이메일 인증이 완료되었습니다. 로그인해주세요.'));
+			}, 3000);
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : '이메일 인증에 실패했습니다.';
+		} finally {
+			isVerifying = false;
+		}
+	}
+
+	function handleGoToLogin() {
+		goto('/login');
+	}
+</script>
+
+<AuthCard title="이메일 인증" description="계정을 활성화하기 위해 이메일을 확인해주세요">
+	{#snippet children()}
+		<ErrorAlert message={errorMessage} type="error" />
+		<ErrorAlert message={successMessage} type="success" />
+
+		{#if isVerifying}
+			<div class="text-center py-8">
+				<div class="animate-spin h-12 w-12 border-4 border-[#FF6B4A] border-t-transparent rounded-full mx-auto mb-4"></div>
+				<p class="text-[#737373]">이메일 인증 중...</p>
+			</div>
+		{:else if isVerified}
+			<div class="text-center py-8">
+				<div class="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+					<svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+					</svg>
+				</div>
+				<p class="text-lg font-medium text-[#171717] mb-2">인증이 완료되었습니다!</p>
+				<p class="text-sm text-[#737373]">잠시 후 로그인 페이지로 이동합니다...</p>
+			</div>
+		{:else if !token}
+			<!-- 토큰이 없는 경우: 인증 대기 화면 -->
+			<div class="text-center py-8">
+				<div class="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+					<svg class="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+					</svg>
+				</div>
+				<p class="text-lg font-medium text-[#171717] mb-2">이메일을 확인해주세요</p>
+				{#if email}
+					<p class="text-sm text-[#737373] mb-4">
+						<span class="font-medium text-[#404040]">{email}</span>로<br />
+						인증 링크를 전송했습니다.
+					</p>
+				{:else}
+					<p class="text-sm text-[#737373] mb-4">
+						회원가입 시 입력하신 이메일로<br />
+						인증 링크를 전송했습니다.
+					</p>
+				{/if}
+				<p class="text-sm text-[#737373] mb-6">
+					이메일의 인증 링크를 클릭하여<br />
+					계정을 활성화해주세요.
+				</p>
+
+				<div class="bg-gray-50 border border-gray-200 rounded-lg p-4 text-left text-sm text-[#737373]">
+					<p class="font-medium text-[#404040] mb-2">💡 이메일이 오지 않았나요?</p>
+					<ul class="space-y-1 list-disc list-inside">
+						<li>스팸 메일함을 확인해주세요</li>
+						<li>이메일 주소가 정확한지 확인해주세요</li>
+						<li>몇 분 후에 다시 시도해주세요</li>
+					</ul>
+				</div>
+			</div>
+
+			<LoadingButton variant="secondary" onclick={handleGoToLogin}>
+				{#snippet children()}
+					로그인 페이지로 이동
+				{/snippet}
+			</LoadingButton>
+		{/if}
+	{/snippet}
+</AuthCard>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,5 +2,13 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		proxy: {
+			'/api': {
+				target: 'http://localhost:8080',
+				changeOrigin: true
+			}
+		}
+	}
 });


### PR DESCRIPTION
# Pull Request

## 변경 사항

프론트엔드 인증 시스템을 완전히 구현했습니다. JWT 토큰을 HttpOnly Cookie로 관리하며, 자동 토큰 갱신, 회원가입/로그인/이메일 인증 플로우를 포함합니다.

### 백엔드 변경사항

**인증 API 수정:**
- `AuthController`: JWT 토큰을 HttpOnly Cookie로 응답하도록 수정
  - `/api/auth/login`: accessToken, refreshToken을 Cookie로 설정
  - `/api/auth/refresh`: Cookie에서 refreshToken 읽기, 새 accessToken을 Cookie로 설정
  - `LoginResponse`: 토큰 필드 제거 (userId, email, emailVerified만 반환)

### 프론트엔드 변경사항

**1. 핵심 인프라:**
- `lib/utils/device.ts`: deviceId 생성 및 관리 (localStorage + UUID)
- `lib/api/client.ts`: API 클라이언트 및 자동 토큰 갱신 인터셉터
  - 401 에러 시 자동 refresh 호출
  - 중복 갱신 방지 로직
  - 갱신 실패 시 로그인 페이지 리다이렉트

**2. 인증 스토어:**
- `lib/stores/auth.svelte.ts`: Cookie 기반 인증 스토어 리팩토링
  - login(): deviceId 자동 생성 및 전송
  - register(): 회원가입 메서드 추가
  - logout(): 로컬 상태 초기화 (임시)
  - fetchUser(): 사용자 정보 조회 (임시 비활성화)

**3. 재사용 컴포넌트:**
- `lib/components/auth/AuthCard.svelte`: 인증 화면 카드 래퍼
- `lib/components/auth/FormInput.svelte`: 폼 입력 필드 (ARIA 속성 자동 처리)
- `lib/components/auth/LoadingButton.svelte`: 로딩 상태 버튼
- `lib/components/auth/ErrorAlert.svelte`: 알림 메시지 (error/success/info)

**4. 인증 페이지:**
- `routes/(public)/signup/+page.svelte`: 회원가입 페이지 완전 재구현
  - 클라이언트 사이드 유효성 검사 (이름, 이메일, 비밀번호, 비밀번호 일치)
  - 비밀번호 정책: 8자 이상, 영문+숫자 포함
  - 필드별 에러 메시지 표시
  - 성공 시 로그인 페이지로 리다이렉트

- `routes/(public)/login/+page.svelte`: 로그인 페이지 리팩토링
  - 회원가입 성공 메시지 표시
  - 이메일 미인증 사용자 처리 (인증 페이지로 리다이렉트)
  - deviceId 자동 처리

- `routes/(public)/verify-email/+page.svelte`: 이메일 인증 페이지 구현
  - 인증 대기, 인증 중, 인증 완료 3가지 상태 화면
  - URL 쿼리 파라미터로 토큰 전달 및 자동 인증
  - 인증 성공 시 3초 후 로그인 페이지 자동 이동

**5. 설정 및 레이아웃:**
- `vite.config.ts`: `/api` 프록시 설정 추가 (→ http://localhost:8080)
- `routes/(app)/+layout.ts`: Cookie 기반 인증 가드 (임시)

**6. 문서:**
- `docs/requirements/auth-api-requirements.md`: 백엔드 추가 API 요구사항
  - `GET /api/auth/me`: 현재 사용자 정보 조회
  - `POST /api/auth/logout`: 로그아웃
- `docs/requirements/frontend-temporary-workaround.md`: 임시 우회 방안

### 백엔드에서 추가로 구현해야 할 사항

**우선순위 높음:**

1. **JWT 인증 필터/인터셉터 구현**
   - Spring Security 설정
   - Cookie에서 accessToken 추출
   - JWT 검증 및 SecurityContext 설정
   - 401 Unauthorized 응답

2. **`GET /api/me` - 현재 사용자 정보 조회**

3. **POST /api/auth/logout - 로그아웃**
  - DB에서 해당 deviceId의 Refresh Token 삭제
  - Cookie 삭제 (MaxAge=0)

**우선순위 중간:**
4. **JWT Claims 확장**
  - Access Token에 name 추가
  - DB 조회 없이 /api/me에서 응답 가능
5. **에러 응답 개선**
  - RFC 7807 ProblemDetail 형식 일관되게 적용
  - 프론트엔드에서 에러 타입별 처리 가능하도록

### 백엔드에서 처리해야 할 에러

#### 현재 발생 가능한 에러:

1. **500 Internal Server Error - 비밀번호 검증 실패**
  - 현상: 비밀번호가 "영문+숫자" 조건을 만족하지 않을 때
  - 원인: 백엔드 비밀번호 정책 검증
  - 해결: 프론트엔드에 동일한 검증 추가 완료 ✅
  - 권장: 400 Bad Request로 변경하고 명확한 에러 메시지 반환

2. **500 Internal Server Error - 이메일 발송 실패**
  - 현상: 회원가입 시 이메일 인증 토큰 발송 실패
  - 원인: SMTP 서버 설정 문제 또는 네트워크 오류
  - 권장: 503 Service Unavailable로 변경하고 재시도 안내

3. **409 Conflict - 이메일 중복**
  - 이미 구현됨
  - 프론트엔드에서 처리 필요

#### 추가 필요한 에러 처리:

4. **401 Unauthorized - 토큰 만료/유효하지 않음**
  - /api/me 구현 후 발생
  - 프론트엔드 자동 토큰 갱신으로 처리
5. **404 Not Found - 사용자 없음**
  - JWT는 유효하지만 DB에 사용자 없음 (삭제된 계정)
  - 401로 처리하여 로그아웃 유도

### 테스트 방법
**회원가입 플로우:**
1. /signup에서 회원가입 (비밀번호: 영문+숫자 8자 이상)
2. 백엔드 이메일 로그 확인 (실제 발송 안될 수 있음)
3. /login에서 로그인 페이지로 리다이렉트 확인
4. 성공 메시지 표시 확인

**로그인 플로우:**
1. /login에서 로그인
2. Cookie에 accessToken, refreshToken 설정 확인 (개발자 도구)
3. /app/backlog로 리다이렉트 확인

**이메일 인증 플로우:**
1. 이메일 미인증 계정으로 로그인 시
2. /verify-email?email=xxx 페이지로 리다이렉트
3. 인증 대기 화면 표시
4. URL에 token 파라미터 추가 시 자동 인증 시도

**자동 토큰 갱신:**
1. 현재는 테스트 불가 (백엔드 인증 필터 미구현)
2. /api/auth/me 구현 후 401 에러 시 자동 갱신 동작 확인


---

### PR 정보
**유형:**
 - [x] 부분 완료 작업:  테스트 플로우가 통과하지 않음, 백엔드 미완료

**이슈 참조:**
Closes #27 

---

**체크리스트:**
- [ ] 로컬 테스트 완료 (회원가입/로그인 플로우)
- [x] 커밋 메시지 컨벤션 준수
- [x] 백엔드 API 프록시 설정 완료
- [x] 비밀번호 검증 규칙 프론트엔드에 적용
- [x] TODO 주석으로 임시 처리 부분 표시
- [x] 요구사항 문서 작성 완료

